### PR TITLE
lndir: use my fork

### DIFF
--- a/build-support/rust/build-rust-crate/test/rcgen-crates.nix
+++ b/build-support/rust/build-rust-crate/test/rcgen-crates.nix
@@ -2972,7 +2972,7 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
-          ${pkgs.xorg.lndir}/bin/lndir ${crate.src}
+          ${pkgs.lndir}/bin/lndir ${crate.src}
 
           # build outputs
           testRoot=target/debug

--- a/pkgs/gobject-introspection/default.nix
+++ b/pkgs/gobject-introspection/default.nix
@@ -44,7 +44,7 @@ then
           eval fixupPhase
           ${lib.concatMapStrings (output: ''
             mkdir -p ${"$" + "${output}"}
-            ${lib.getExe buildPackages.xorg.lndir} ${overriddenUnwrappedGir.${output}} ${"$" + "${output}"}
+            ${lib.getExe buildPackages.lndir} ${overriddenUnwrappedGir.${output}} ${"$" + "${output}"}
           '') overriddenUnwrappedGir.outputs}
 
           cp $dev/bin/g-ir-compiler $dev/bin/.g-ir-compiler-wrapped
@@ -99,7 +99,7 @@ else
         eval fixupPhase
         ${lib.concatMapStrings (output: ''
           mkdir -p ${"$" + "${output}"}
-          ${lib.getExe buildPackages.xorg.lndir} ${overriddenUnwrappedGir.${output}} ${"$" + "${output}"}
+          ${lib.getExe buildPackages.lndir} ${overriddenUnwrappedGir.${output}} ${"$" + "${output}"}
         '') overriddenUnwrappedGir.outputs}
       '';
     })

--- a/pkgs/lndir/default.nix
+++ b/pkgs/lndir/default.nix
@@ -1,0 +1,35 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  lib,
+  coreutils,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  name = "lndir";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jonringer";
+    repo = "lndir-simple";
+    rev = "v${version}";
+    hash = "sha256-dSi+bufyjgyVDAARb5V1BY7rbI26QXU/l36pWW6P6DM=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  dontBuild = true;
+  installPhase = ''
+    install -D lndir.sh $out/bin/lndir
+    wrapProgram $out/bin/lndir \
+      --prefix PATH : ${lib.makeBinPath [ coreutils ]}
+  '';
+
+  meta = {
+    description = "Xorg's lndir utility, but in simple script form";
+    licenses = [ lib.licenses.gpl3Plus ];
+  };
+}


### PR DESCRIPTION
avoid having to bring in `xorg` package scope just for a single utility. Help reduce instantiate logic of stdenv quite a bit