### PR TITLE
treewide: adopt named sources

### DIFF
--- a/build-support/fetchgit/default.nix
+++ b/build-support/fetchgit/default.nix
@@ -1,110 +1,230 @@
-{lib, stdenvNoCC, git, git-lfs, cacert}: let
-  urlToName = url: rev: let
-    inherit (lib) removeSuffix splitString last;
-    base = last (splitString ":" (baseNameOf (removeSuffix "/" url)));
-
-    matched = builtins.match "(.*)\\.git" base;
-
-    short = builtins.substring 0 7 rev;
-
-    appendShort = lib.optionalString ((builtins.match "[a-f0-9]*" rev) != null) "-${short}";
-  in "${if matched == null then base else builtins.head matched}${appendShort}";
-in
-lib.makeOverridable (
-{ url, rev ? "HEAD", sha256 ? "", hash ? "", leaveDotGit ? deepClone
-, fetchSubmodules ? true, deepClone ? false
-, branchName ? null
-, sparseCheckout ? []
-, nonConeMode ? false
-, name ? urlToName url rev
-, # Shell code executed after the file has been fetched
-  # successfully. This can do things like check or transform the file.
-  postFetch ? ""
-, preferLocalBuild ? true
-, fetchLFS ? false
-, # Shell code to build a netrc file for BASIC auth
-  netrcPhase ? null
-, # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
-  # needed for netrcPhase
-  netrcImpureEnvVars ? []
-, meta ? {}
-, allowedRequisites ? null
+{
+  config,
+  lib,
+  stdenvNoCC,
+  writeText,
+  pkgsBuildHost,
 }:
 
-/* NOTE:
-   fetchgit has one problem: git fetch only works for refs.
-   This is because fetching arbitrary (maybe dangling) commits creates garbage collection risks
-   and checking whether a commit belongs to a ref is expensive. This may
-   change in the future when some caching is added to git (?)
-   Usually refs are either tags (refs/tags/*) or branches (refs/heads/*)
-   Cloning branches will make the hash check fail when there is an update.
-   But not all patches we want can be accessed by tags.
+let
+  urlToName =
+    {
+      url,
+      rev,
+      append,
+    }:
+    let
+      shortRev = lib.sources.shortRev rev;
+      appendShort = lib.optionalString ((builtins.match "[a-f0-9]*" rev) != null) "-${shortRev}";
+    in
+    "${lib.sources.urlToName url}${if append == "" then appendShort else append}";
 
-   The workaround is getting the last n commits so that it's likely that they
-   still contain the hash we want.
+  getRevWithTag =
+    {
+      rev ? null,
+      tag ? null,
+    }:
+    if tag != null && rev != null then
+      throw "fetchgit requires one of either `rev` or `tag` to be provided (not both)."
+    else if tag != null then
+      "refs/tags/${tag}"
+    else if rev != null then
+      rev
+    else
+      # FIXME fetching HEAD if no rev or tag is provided is problematic at best
+      "HEAD";
+in
 
-   for now : increase depth iteratively (TODO)
+lib.makeOverridable (
+  lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
 
-   real fix: ask git folks to add a
-   git fetch $HASH contained in $BRANCH
-   facility because checking that $HASH is contained in $BRANCH is less
-   expensive than fetching --depth $N.
-   Even if git folks implemented this feature soon it may take years until
-   server admins start using the new version?
-*/
+    excludeDrvArgNames = [
+      # Additional stdenv.mkDerivation arguments from derived fetchers.
+      "derivationArgs"
 
-assert deepClone -> leaveDotGit;
-assert nonConeMode -> (sparseCheckout != []);
+      # Hashes, handled by `lib.fetchers.withNormalizedHash`
+      # whose outputs contain outputHash* attributes.
+      "hash"
+      "sha256"
+    ];
 
-if hash != "" && sha256 != "" then
-  throw "Only one of sha256 or hash can be set"
-else if builtins.isString sparseCheckout then
-  # Changed to throw on 2023-06-04
-  throw "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
-else
-stdenvNoCC.mkDerivation {
-  inherit name;
-  builder = ./builder.sh;
-  fetcher = ./nix-prefetch-git;
+    extendDrvArgs =
+      finalAttrs:
+      lib.fetchers.withNormalizedHash { } (
+        # NOTE Please document parameter additions or changes in
+        #   ../../../doc/build-helpers/fetchers.chapter.md
+        {
+          url,
+          tag ? null,
+          rev ? null,
+          name ? urlToName {
+            inherit url;
+            rev = lib.revOrTag finalAttrs.revCustom finalAttrs.tag;
+            # when rootDir is specified, avoid invalidating the result when rev changes
+            append = if rootDir != "" then "-${lib.strings.sanitizeDerivationName rootDir}" else "";
+          },
+          leaveDotGit ? deepClone || fetchTags,
+          outputHash ? lib.fakeHash,
+          outputHashAlgo ? null,
+          fetchSubmodules ? true,
+          deepClone ? false,
+          branchName ? null,
+          sparseCheckout ? lib.optional (rootDir != "") rootDir,
+          nonConeMode ? rootDir != "",
+          nativeBuildInputs ? [ ],
+          # Shell code executed before the file has been fetched.  This, in
+          # particular, can do things like set NIX_PREFETCH_GIT_CHECKOUT_HOOK to
+          # run operations between the checkout completing and deleting the .git
+          # directory.
+          preFetch ? "",
+          # Shell code executed after the file has been fetched
+          # successfully. This can do things like check or transform the file.
+          postFetch ? "",
+          preferLocalBuild ? true,
+          fetchLFS ? false,
+          # Shell code to build a netrc file for BASIC auth
+          netrcPhase ? null,
+          # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
+          # needed for netrcPhase
+          netrcImpureEnvVars ? [ ],
+          passthru ? { },
+          meta ? { },
+          allowedRequisites ? null,
+          # fetch all tags after tree (useful for git describe)
+          fetchTags ? false,
+          # make this subdirectory the root of the result
+          rootDir ? "",
+          # GIT_CONFIG_GLOBAL (as a file)
+          gitConfigFile ? config.gitConfigFile,
+          # Additional stdenvNoCC.mkDerivation arguments.
+          # It is typically for derived fetchers to pass down additional arguments,
+          # and the specified arguments have lower precedence than other mkDerivation arguments.
+          derivationArgs ? { },
+        }:
 
-  nativeBuildInputs = [ git ]
-    ++ lib.optionals fetchLFS [ git-lfs ];
+        /*
+          NOTE:
+          fetchgit has one problem: git fetch only works for refs.
+          This is because fetching arbitrary (maybe dangling) commits creates garbage collection risks
+          and checking whether a commit belongs to a ref is expensive. This may
+          change in the future when some caching is added to git (?)
+          Usually refs are either tags (refs/tags/*) or branches (refs/heads/*)
+          Cloning branches will make the hash check fail when there is an update.
+          But not all patches we want can be accessed by tags.
 
-  outputHashAlgo = if hash != "" then null else "sha256";
-  outputHashMode = "recursive";
-  outputHash = if hash != "" then
-    hash
-  else if sha256 != "" then
-    sha256
-  else
-    lib.fakeSha256;
+          The workaround is getting the last n commits so that it's likely that they
+          still contain the hash we want.
 
-  # git-sparse-checkout(1) says:
-  # > When the --stdin option is provided, the directories or patterns are read
-  # > from standard in as a newline-delimited list instead of from the arguments.
-  sparseCheckout = builtins.concatStringsSep "\n" sparseCheckout;
+          for now : increase depth iteratively (TODO)
 
-  inherit url rev leaveDotGit fetchLFS fetchSubmodules deepClone branchName nonConeMode postFetch;
+          real fix: ask git folks to add a
+          git fetch $HASH contained in $BRANCH
+          facility because checking that $HASH is contained in $BRANCH is less
+          expensive than fetching --depth $N.
+          Even if git folks implemented this feature soon it may take years until
+          server admins start using the new version?
+        */
 
-  postHook = if netrcPhase == null then null else ''
-    ${netrcPhase}
-    # required that git uses the netrc file
-    mv {,.}netrc
-    export NETRC=$PWD/.netrc
-    export HOME=$PWD
-  '';
+        assert nonConeMode -> (sparseCheckout != [ ]);
+        assert fetchTags -> leaveDotGit;
+        assert rootDir != "" -> !leaveDotGit;
 
-  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+        if builtins.isString sparseCheckout then
+          # Changed to throw on 2023-06-04
+          throw
+            "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
+        else
+          derivationArgs
+          // {
+            inherit name;
 
-  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ netrcImpureEnvVars ++ [
-    "GIT_PROXY_COMMAND" "NIX_GIT_SSL_CAINFO" "SOCKS_SERVER"
-  ];
+            builder = ./builder.sh;
+            fetcher = ./nix-prefetch-git;
 
+            nativeBuildInputs = [
+              pkgsBuildHost.git
+              pkgsBuildHost.cacert
+            ]
+            ++ lib.optionals fetchLFS [ pkgsBuildHost.git-lfs ]
+            ++ nativeBuildInputs;
 
-  inherit preferLocalBuild meta allowedRequisites;
+            inherit outputHash outputHashAlgo;
+            outputHashMode = "recursive";
 
-  passthru = {
-    gitRepoUrl = url;
-  };
-}
+            # git-sparse-checkout(1) says:
+            # > When the --stdin option is provided, the directories or patterns are read
+            # > from standard in as a newline-delimited list instead of from the arguments.
+            sparseCheckout = builtins.concatStringsSep "\n" sparseCheckout;
+
+            inherit
+              url
+              leaveDotGit
+              fetchLFS
+              fetchSubmodules
+              deepClone
+              branchName
+              nonConeMode
+              preFetch
+              postFetch
+              fetchTags
+              rootDir
+              gitConfigFile
+              ;
+            inherit tag;
+            revCustom = rev;
+            rev = getRevWithTag {
+              inherit (finalAttrs) tag;
+              rev = finalAttrs.revCustom;
+            };
+
+            postHook =
+              if netrcPhase == null then
+                null
+              else
+                ''
+                  ${netrcPhase}
+                  # required that git uses the netrc file
+                  mv {,.}netrc
+                  export NETRC=$PWD/.netrc
+                  export HOME=$PWD
+                '';
+
+            impureEnvVars =
+              lib.fetchers.proxyImpureEnvVars
+              ++ netrcImpureEnvVars
+              ++ [
+                "GIT_PROXY_COMMAND"
+                "NIX_GIT_SSL_CAINFO"
+                "SOCKS_SERVER"
+
+                # This is a parameter intended to be set by setup hooks or preFetch
+                # scripts that want per-URL control over HTTP proxies used by Git
+                # (if per-URL control isn't needed, `http_proxy` etc. will
+                # suffice). It must be a whitespace-separated (with backslash as an
+                # escape character) list of pairs like this:
+                #
+                #   http://domain1/path1 proxy1 https://domain2/path2 proxy2
+                #
+                # where the URLs are as documented in the `git-config` manual page
+                # under `http.<url>.*`, and the proxies are as documented on the
+                # same page under `http.proxy`.
+                "FETCHGIT_HTTP_PROXIES"
+              ];
+
+            inherit preferLocalBuild meta allowedRequisites;
+
+            passthru = {
+              gitRepoUrl = url;
+            }
+            // passthru;
+          }
+      );
+
+    # No ellipsis.
+    inheritFunctionArgs = false;
+  }
 )
+// {
+  inherit getRevWithTag;
+}

--- a/build-support/fetchurl/default.nix
+++ b/build-support/fetchurl/default.nix
@@ -1,191 +1,335 @@
-{ lib, buildPackages ? { inherit stdenvNoCC; }, stdenvNoCC
-, curl # Note that `curl' may be `null', in case of the native stdenvNoCC.
-, cacert ? null }:
+{
+  lib,
+  buildPackages ? {
+    inherit stdenvNoCC;
+  },
+  stdenvNoCC,
+  curl, # Note that `curl' may be `null', in case of the native stdenvNoCC.
+  cacert ? null,
+  config,
+}:
 
 let
 
-  mirrors = import ./mirrors.nix;
+  inherit (config)
+    hashedMirrors
+    rewriteURL;
+
+  mirrors = import ./mirrors.nix // {
+    inherit hashedMirrors;
+  };
 
   # Write the list of mirrors to a file that we can reuse between
   # fetchurl instantiations, instead of passing the mirrors to
   # fetchurl instantiations via environment variables.  This makes the
   # resulting store derivations (.drv files) much smaller, which in
   # turn makes nix-env/nix-instantiate faster.
-  mirrorsFile =
-    buildPackages.stdenvNoCC.mkDerivation ({
+  mirrorsFile = buildPackages.stdenvNoCC.mkDerivation (
+    {
       name = "mirrors-list";
       strictDeps = true;
       builder = ./write-mirror-list.sh;
       preferLocalBuild = true;
-    } // mirrors);
+    }
+    // mirrors
+  );
 
   # Names of the master sites that are mirrored (i.e., "sourceforge",
   # "gnu", etc.).
   sites = builtins.attrNames mirrors;
 
-  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
-    # This variable allows the user to pass additional options to curl
-    "NIX_CURL_FLAGS"
+  impureEnvVars =
+    lib.fetchers.proxyImpureEnvVars
+    ++ [
+      # This variable allows the user to pass additional options to curl
+      "NIX_CURL_FLAGS"
 
-    # This variable allows the user to override hashedMirrors from the
-    # command-line.
-    "NIX_HASHED_MIRRORS"
+      # This variable allows the user to override hashedMirrors from the
+      # command-line.
+      "NIX_HASHED_MIRRORS"
 
-    # This variable allows overriding the timeout for connecting to
-    # the hashed mirrors.
-    "NIX_CONNECT_TIMEOUT"
-  ] ++ (map (site: "NIX_MIRRORS_${site}") sites);
+      # This variable allows overriding the timeout for connecting to
+      # the hashed mirrors.
+      "NIX_CONNECT_TIMEOUT"
+    ]
+    ++ (map (site: "NIX_MIRRORS_${site}") sites);
 
 in
 
-{ # URL to fetch.
-  url ? ""
+lib.extendMkDerivation {
+  constructDrv = stdenvNoCC.mkDerivation;
 
-, # Alternatively, a list of URLs specifying alternative download
-  # locations.  They are tried in order.
-  urls ? []
+  excludeDrvArgNames = [
+    # Passed via passthru
+    "url"
 
-, # Additional curl options needed for the download to succeed.
-  # Warning: Each space (no matter the escaping) will start a new argument.
-  # If you wish to pass arguments with spaces, use `curlOptsList`
-  curlOpts ? ""
+    # Additional stdenv.mkDerivation arguments from derived fetchers.
+    "derivationArgs"
 
-, # Additional curl options needed for the download to succeed.
-  curlOptsList ? []
+    # Hash attributes will be map to the corresponding outputHash*
+    "hash"
+    "sha1"
+    "sha256"
+    "sha512"
+  ];
 
-, # Name of the file.  If empty, use the basename of `url' (or of the
-  # first element of `urls').
-  name ? ""
+  extendDrvArgs =
+    finalAttrs:
+    {
+      # URL to fetch.
+      url ? "",
 
-  # for versioned downloads optionally take pname + version.
-, pname ? ""
-, version ? ""
+      # Alternatively, a list of URLs specifying alternative download
+      # locations.  They are tried in order.
+      urls ? [ ],
 
-, # SRI hash.
-  hash ? ""
+      # Additional curl options needed for the download to succeed.
+      # Warning: Each space (no matter the escaping) will start a new argument.
+      # If you wish to pass arguments with spaces, use `curlOptsList`
+      curlOpts ? "",
 
-, # Legacy ways of specifying the hash.
-  outputHash ? ""
-, outputHashAlgo ? ""
-, sha1 ? ""
-, sha256 ? ""
-, sha512 ? ""
+      # Additional curl options needed for the download to succeed.
+      curlOptsList ? [ ],
 
-, recursiveHash ? false
+      # Name of the file when pname + version is unspecified.
+      # Default to the basename of `url' (or of the first element of `urls').
+      name ? null,
 
-, # Shell code to build a netrc file for BASIC auth
-  netrcPhase ? null
+      # for versioned downloads optionally take pname + version.
+      pname ? null,
+      version ? null,
 
-, # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
-  # needed for netrcPhase
-  netrcImpureEnvVars ? []
+      # SRI hash.
+      hash ? "",
 
-, # Shell code executed after the file has been fetched
-  # successfully. This can do things like check or transform the file.
-  postFetch ? ""
+      # Legacy ways of specifying the hash.
+      outputHash ? "",
+      outputHashAlgo ? "",
+      sha1 ? "",
+      sha256 ? "",
+      sha512 ? "",
 
-, # Whether to download to a temporary path rather than $out. Useful
-  # in conjunction with postFetch. The location of the temporary file
-  # is communicated to postFetch via $downloadedFile.
-  downloadToTemp ? false
+      recursiveHash ? false,
 
-, # If true, set executable bit on downloaded file
-  executable ? false
+      # Shell code to build a netrc file for BASIC auth
+      netrcPhase ? null,
 
-, # If set, don't download the file, but write a list of all possible
-  # URLs (resulting from resolving mirror:// URLs) to $out.
-  showURLs ? false
+      # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
+      # needed for netrcPhase
+      netrcImpureEnvVars ? [ ],
 
-, # Meta information, if any.
-  meta ? {}
+      # Shell code executed after the file has been fetched
+      # successfully. This can do things like check or transform the file.
+      postFetch ? "",
 
-  # Passthru information, if any.
-, passthru ? {}
-  # Doing the download on a remote machine just duplicates network
-  # traffic, so don't do that by default
-, preferLocalBuild ? true
+      # Whether to download to a temporary path rather than $out. Useful
+      # in conjunction with postFetch. The location of the temporary file
+      # is communicated to postFetch via $downloadedFile.
+      downloadToTemp ? false,
 
-  # Additional packages needed as part of a fetch
-, nativeBuildInputs ? [ ]
-}:
+      # If true, set executable bit on downloaded file
+      executable ? false,
 
-let
-  urls_ =
-    if urls != [] && url == "" then
-      (if lib.isList urls then urls
-       else throw "`urls` is not a list")
-    else if urls == [] && url != "" then
-      (if lib.isString url then [url]
-       else throw "`url` is not a string")
-    else throw "fetchurl requires either `url` or `urls` to be set";
+      # If set, don't download the file, but write a list of all possible
+      # URLs (resulting from resolving mirror:// URLs) to $out.
+      showURLs ? false,
 
-  hash_ =
-    if with lib.lists; length (filter (s: s != "") [ hash outputHash sha1 sha256 sha512 ]) > 1
-    then throw "multiple hashes passed to fetchurl" else
+      # Meta information, if any.
+      meta ? { },
 
-    if hash != "" then { outputHashAlgo = null; outputHash = hash; }
-    else if outputHash != "" then
-      if outputHashAlgo != "" then { inherit outputHashAlgo outputHash; }
-      else throw "fetchurl was passed outputHash without outputHashAlgo"
-    else if sha512 != "" then { outputHashAlgo = "sha512"; outputHash = sha512; }
-    else if sha256 != "" then { outputHashAlgo = "sha256"; outputHash = sha256; }
-    else if sha1   != "" then { outputHashAlgo = "sha1";   outputHash = sha1; }
-    else if cacert != null then { outputHashAlgo = "sha256"; outputHash = ""; }
-    else throw "fetchurl requires a hash for fixed-output derivation: ${lib.concatStringsSep ", " urls_}";
-in
+      # Passthru information, if any.
+      passthru ? { },
+      # Doing the download on a remote machine just duplicates network
+      # traffic, so don't do that by default
+      preferLocalBuild ? true,
 
-assert (lib.isList curlOpts) -> lib.warn ''
-    fetchurl for ${toString (builtins.head urls_)}: curlOpts is a list (${lib.generators.toPretty { multiline = false; } curlOpts}), which is not supported anymore.
-    - If you wish to get the same effect as before, for elements with spaces (even if escaped) to expand to multiple curl arguments, use a string argument instead:
-      curlOpts = ${lib.strings.escapeNixString (toString curlOpts)};
-    - If you wish for each list element to be passed as a separate curl argument, allowing arguments to contain spaces, use curlOptsList instead:
-      curlOptsList = [ ${lib.concatMapStringsSep " " lib.strings.escapeNixString curlOpts} ];'' true;
+      # Additional packages needed as part of a fetch
+      nativeBuildInputs ? [ ],
 
-stdenvNoCC.mkDerivation ((
-  if (pname != "" && version != "") then
-    { inherit pname version; }
-  else
-    { name =
-      if showURLs then "urls"
-      else if name != "" then name
-      else baseNameOf (toString (builtins.head urls_));
-    }
-) // {
-  builder = ./builder.sh;
+      # Additional stdenvNoCC.mkDerivation arguments.
+      # It is typically for derived fetchers to pass down additional arguments,
+      # and the specified arguments have lower precedence than other mkDerivation arguments.
+      derivationArgs ? { },
+    }@args:
 
-  nativeBuildInputs = [ curl ] ++ nativeBuildInputs;
+    let
+      preRewriteUrls =
+        if urls != [ ] && url == "" then
+          (
+            if lib.isList urls then urls else throw "`urls` is not a list: ${lib.generators.toPretty { } urls}"
+          )
+        else if urls == [ ] && url != "" then
+          (
+            if lib.isString url then
+              [ url ]
+            else
+              throw "`url` is not a string: ${lib.generators.toPretty { } urls}"
+          )
+        else
+          throw "fetchurl requires either `url` or `urls` to be set: ${lib.generators.toPretty { } args}";
 
-  urls = urls_;
+      urls_ =
+        let
+          u = lib.lists.filter (url: lib.isString url) (map rewriteURL preRewriteUrls);
+        in
+        if u == [ ] then throw "urls is empty after rewriteURL (was ${toString preRewriteUrls})" else u;
 
-  # If set, prefer the content-addressable mirrors
-  # (http://tarballs.nixos.org) over the original URLs.
-  preferHashedMirrors = true;
+      hash_ =
+        if
+          with lib.lists;
+          length (
+            filter (s: s != "") [
+              hash
+              outputHash
+              sha1
+              sha256
+              sha512
+            ]
+          ) > 1
+        then
+          throw "multiple hashes passed to fetchurl: ${lib.generators.toPretty { } urls_}"
+        else
 
-  # New-style output content requirements.
-  inherit (hash_) outputHashAlgo outputHash;
+        if hash != "" then
+          {
+            outputHashAlgo = null;
+            outputHash = hash;
+          }
+        else if outputHash != "" then
+          if outputHashAlgo != "" then
+            { inherit outputHashAlgo outputHash; }
+          else
+            throw "fetchurl was passed outputHash without outputHashAlgo: ${lib.generators.toPretty { } urls_}"
+        else if sha512 != "" then
+          {
+            outputHashAlgo = "sha512";
+            outputHash = sha512;
+          }
+        else if sha256 != "" then
+          {
+            outputHashAlgo = "sha256";
+            outputHash = sha256;
+          }
+        else if sha1 != "" then
+          {
+            outputHashAlgo = "sha1";
+            outputHash = sha1;
+          }
+        else if cacert != null then
+          {
+            outputHashAlgo = "sha256";
+            outputHash = "";
+          }
+        else
+          throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty { } urls_}";
 
-  SSL_CERT_FILE = if (hash_.outputHash == "" || hash_.outputHash == lib.fakeSha256 || hash_.outputHash == lib.fakeSha512 || hash_.outputHash == lib.fakeHash)
-                  then "${cacert}/etc/ssl/certs/ca-bundle.crt"
-                  else "/no-cert-file.crt";
+      resolvedUrl =
+        let
+          mirrorSplit = lib.match "mirror://([[:alpha:]]+)/(.+)" url;
+          mirrorName = lib.head mirrorSplit;
+          mirrorList =
+            if lib.hasAttr mirrorName mirrors then
+              mirrors."${mirrorName}"
+            else
+              throw "unknown mirror:// site ${mirrorName}";
+        in
+        if mirrorSplit == null || mirrorName == null then
+          url
+        else
+          "${lib.head mirrorList}${lib.elemAt mirrorSplit 1}";
+    in
 
-  outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
+    derivationArgs
+    // {
+      name =
+        if finalAttrs.pname or null != null && finalAttrs.version or null != null then
+          "${finalAttrs.pname}-${finalAttrs.version}"
+        else if showURLs then
+          "urls"
+        else if name != null then
+          name
+        else
+          baseNameOf (toString (lib.head urls_));
 
-  inherit curlOpts;
-  curlOptsList = lib.escapeShellArgs curlOptsList;
-  inherit showURLs mirrorsFile postFetch downloadToTemp executable;
+      builder = ./builder.sh;
 
-  impureEnvVars = impureEnvVars ++ netrcImpureEnvVars;
+      nativeBuildInputs = [ curl ] ++ nativeBuildInputs;
 
-  # This couples nixpkgs lib state to curl calls
-  # nixpkgsVersion = lib.trivial.release;
+      urls = urls_;
 
-  inherit preferLocalBuild;
+      # If set, prefer the content-addressable mirrors
+      # (http://tarballs.nixos.org) over the original URLs.
+      preferHashedMirrors = false;
 
-  postHook = if netrcPhase == null then null else ''
-    ${netrcPhase}
-    curlOpts="$curlOpts --netrc-file $PWD/netrc"
-  '';
+      # New-style output content requirements.
+      inherit (hash_) outputHashAlgo outputHash;
 
-  inherit meta;
-  passthru = { inherit url; } // passthru;
-})
+      # Disable TLS verification only when we know the hash and no credentials are
+      # needed to access the resource
+      SSL_CERT_FILE =
+        if
+          (
+            hash_.outputHash == ""
+            || hash_.outputHash == lib.fakeSha256
+            || hash_.outputHash == lib.fakeSha512
+            || hash_.outputHash == lib.fakeHash
+            || netrcPhase != null
+          )
+        then
+          "${cacert}/etc/ssl/certs/ca-bundle.crt"
+        else
+          "/no-cert-file.crt";
+
+      outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
+
+      curlOpts = lib.warnIf (lib.isList curlOpts) (
+        let
+          url = toString (builtins.head urls_);
+          curlOptsRepresentation = lib.generators.toPretty { multiline = false; } curlOpts;
+          curlOptsAsStringRepresentation = lib.strings.escapeNixString (toString curlOpts);
+          curlOptsListElementsRepresentation =
+            lib.concatMapStringsSep " " lib.strings.escapeNixString
+              curlOpts;
+        in
+        ''
+          fetchurl for ${url}: curlOpts is a list (${curlOptsRepresentation}), which is not supported anymore.
+          - If you wish to get the same effect as before, for elements with spaces (even if escaped) to expand to multiple curl arguments, use a string argument instead:
+            curlOpts = ${curlOptsAsStringRepresentation};
+          - If you wish for each list element to be passed as a separate curl argument, allowing arguments to contain spaces, use curlOptsList instead:
+            curlOptsList = [ ${curlOptsListElementsRepresentation} ];
+        ''
+      ) curlOpts;
+
+      curlOptsList = lib.escapeShellArgs curlOptsList;
+
+      inherit
+        showURLs
+        mirrorsFile
+        postFetch
+        downloadToTemp
+        executable
+        ;
+
+      impureEnvVars = impureEnvVars ++ netrcImpureEnvVars;
+
+      inherit preferLocalBuild;
+
+      postHook =
+        if netrcPhase == null then
+          null
+        else
+          ''
+            ${netrcPhase}
+            curlOpts="$curlOpts --netrc-file $PWD/netrc"
+          '';
+
+      inherit meta;
+      passthru = {
+        inherit url resolvedUrl;
+      }
+      // passthru;
+    };
+
+  # No ellipsis
+  inheritFunctionArgs = false;
+}

--- a/build-support/fetchzip/default.nix
+++ b/build-support/fetchzip/default.nix
@@ -5,73 +5,120 @@
 # (e.g. due to minor changes in the compression algorithm, or changes
 # in timestamps).
 
-{ lib, fetchurl, withUnzip ? true, unzip, glibcLocalesUtf8 }:
+{
+  lib,
+  fetchurl,
+  withUnzip ? true,
+  unzip,
+  glibcLocalesUtf8,
+}:
 
-{ name ? "source"
-, url ? ""
-, urls ? []
-, nativeBuildInputs ? []
-, postFetch ? ""
-, extraPostFetch ? ""
+lib.extendMkDerivation {
+  constructDrv = fetchurl;
 
-# Optionally move the contents of the unpacked tree up one level.
-, stripRoot ? true
-# Allows to set the extension for the intermediate downloaded
-# file. This can be used as a hint for the unpackCmdHooks to select
-# an appropriate unpacking tool.
-, extension ? null
+  excludeDrvArgNames = [
+    "extraPostFetch"
 
-# the rest are given to fetchurl as is
-, ... } @ args:
+    # Pass via derivationArgs
+    "extension"
+    "stripRoot"
+  ];
 
-assert (extraPostFetch != "") -> lib.warn "use 'postFetch' instead of 'extraPostFetch' with 'fetchzip' and 'fetchFromGitHub' or 'fetchFromGitLab'." true;
+  extendDrvArgs =
+    finalAttrs:
+    {
+      url ? "",
+      urls ? [ ],
+      name ? lib.sources.repoRevToName (if url != "" then url else builtins.head urls) null "unpacked",
+      nativeBuildInputs ? [ ],
+      postFetch ? "",
+      extraPostFetch ? "",
 
-let
-  tmpFilename =
-    if extension != null
-    then "download.${extension}"
-    else baseNameOf (if url != "" then url else builtins.head urls);
-in
+      # Optionally move the contents of the unpacked tree up one level.
+      stripRoot ? true,
+      # Allows to set the extension for the intermediate downloaded
+      # file. This can be used as a hint for the unpackCmdHooks to select
+      # an appropriate unpacking tool.
+      extension ? null,
 
-fetchurl ({
-  inherit name;
-  recursiveHash = true;
+      # Additional stdenvNoCC.mkDerivation arguments.
+      # It is typically for derived fetchers to pass down additional arguments,
+      # and the specified arguments have lower precedence than other mkDerivation arguments.
+      derivationArgs ? { },
 
-  downloadToTemp = true;
+      # the rest are given to fetchurl as is
+      ...
+    }@args:
 
-  # Have to pull in glibcLocalesUtf8 for unzip in setup-hook.sh to handle
-  # UTF-8 aware locale:
-  #   https://github.com/NixOS/nixpkgs/issues/176225#issuecomment-1146617263
-  nativeBuildInputs = lib.optionals withUnzip [ unzip glibcLocalesUtf8 ] ++ nativeBuildInputs;
+    let
+      tmpFilename =
+        if finalAttrs.extension != null then
+          "download.${finalAttrs.extension}"
+        else
+          baseNameOf (if url != "" then url else builtins.head urls);
+    in
 
-  postFetch =
-    ''
-      unpackDir="$TMPDIR/unpack"
-      mkdir "$unpackDir"
-      cd "$unpackDir"
+    {
+      inherit name;
+      recursiveHash = true;
 
-      renamed="$TMPDIR/${tmpFilename}"
-      mv "$downloadedFile" "$renamed"
-      unpackFile "$renamed"
-      chmod -R +w "$unpackDir"
-    '' + (if stripRoot then ''
-      if [ $(ls -A "$unpackDir" | wc -l) != 1 ]; then
-        echo "error: zip file must contain a single file or directory."
-        echo "hint: Pass stripRoot=false; to fetchzip to assume flat list of files."
-        exit 1
-      fi
-      fn=$(cd "$unpackDir" && ls -A)
-      if [ -f "$unpackDir/$fn" ]; then
-        mkdir $out
-      fi
-      mv "$unpackDir/$fn" "$out"
-    '' else ''
-      mv "$unpackDir" "$out"
-    '') + ''
-      ${postFetch}
-      ${extraPostFetch}
-      chmod 755 "$out"
-    '';
-    # ^ Remove non-owner write permissions
-    # Fixes https://github.com/NixOS/nixpkgs/issues/38649
-} // removeAttrs args [ "stripRoot" "extraPostFetch" "postFetch" "extension" "nativeBuildInputs" ])
+      downloadToTemp = true;
+
+      # Have to pull in glibcLocalesUtf8 for unzip in setup-hook.sh to handle
+      # UTF-8 aware locale:
+      #   https://github.com/NixOS/nixpkgs/issues/176225#issuecomment-1146617263
+      nativeBuildInputs =
+        lib.optionals withUnzip [
+          unzip
+          glibcLocalesUtf8
+        ]
+        ++ nativeBuildInputs;
+
+      postFetch = ''
+        unpackDir="$TMPDIR/unpack"
+        mkdir "$unpackDir"
+        cd "$unpackDir"
+
+        renamed="$TMPDIR/${tmpFilename}"
+        mv "$downloadedFile" "$renamed"
+        unpackFile "$renamed"
+        chmod -R +w "$unpackDir"
+      ''
+      + (
+        if finalAttrs.stripRoot then
+          ''
+            if [ $(ls -A "$unpackDir" | wc -l) != 1 ]; then
+              echo "error: zip file must contain a single file or directory."
+              echo "hint: Pass stripRoot=false; to fetchzip to assume flat list of files."
+              exit 1
+            fi
+            fn=$(cd "$unpackDir" && ls -A)
+            if [ -f "$unpackDir/$fn" ]; then
+              mkdir $out
+            fi
+            mv "$unpackDir/$fn" "$out"
+          ''
+        else
+          ''
+            mv "$unpackDir" "$out"
+          ''
+      )
+      + ''
+        ${postFetch}
+        ${lib.warnIf (extraPostFetch != "")
+          "use 'postFetch' instead of 'extraPostFetch' with 'fetchzip' and 'fetchFromGitHub' or 'fetchFromGitLab'."
+          extraPostFetch
+        }
+        chmod 755 "$out"
+      '';
+      # ^ Remove non-owner write permissions
+      # Fixes https://github.com/NixOS/nixpkgs/issues/38649
+
+      derivationArgs = derivationArgs // {
+        inherit
+          extension
+          stripRoot
+          ;
+      };
+    };
+}

--- a/pins.nix
+++ b/pins.nix
@@ -1,7 +1,7 @@
 {
   lib = import (builtins.fetchGit {
     url = "https://github.com/ekala-project/nix-lib.git";
-    rev = "16fc631315c3937761d1ee22126b4b7818944fa5";
+    rev = "3cabe9bf231b6127b27a7826d0421b60cabcdde9";
   });
 }
 

--- a/pkgs/fetchFromGitHub/default.nix
+++ b/pkgs/fetchFromGitHub/default.nix
@@ -1,68 +1,186 @@
-{ lib, fetchgit, fetchzip }:
+{
+  lib,
+  fetchgit,
+  fetchzip,
+}:
 
 lib.makeOverridable (
-{ owner, repo, rev, name ? "source"
-, fetchSubmodules ? false, leaveDotGit ? null
-, deepClone ? false, private ? false, forceFetchGit ? false
-, sparseCheckout ? []
-, githubBase ? "github.com", varPrefix ? null
-, meta ? { }
-, ... # For hash agility
-}@args:
+  {
+    owner,
+    repo,
+    tag ? null,
+    rev ? null,
+    name ? lib.sources.repoRevToName repo (lib.revOrTag rev tag) "github",
+    fetchSubmodules ? false,
+    leaveDotGit ? null,
+    deepClone ? false,
+    private ? false,
+    forceFetchGit ? false,
+    fetchLFS ? false,
+    rootDir ? "",
+    sparseCheckout ? lib.optional (rootDir != "") rootDir,
+    githubBase ? "github.com",
+    varPrefix ? null,
+    passthru ? { },
+    meta ? { },
+    ... # For hash agility
+  }@args:
 
-let
-
-  position = (if args.meta.description or null != null
-    then builtins.unsafeGetAttrPos "description" args.meta
-    else builtins.unsafeGetAttrPos "rev" args
+  assert (
+    lib.assertMsg (lib.xor (tag == null) (
+      rev == null
+    )) "fetchFromGitHub requires one of either `rev` or `tag` to be provided (not both)."
   );
-  baseUrl = "https://${githubBase}/${owner}/${repo}";
-  newMeta = meta // {
-    homepage = meta.homepage or baseUrl;
-  } // lib.optionalAttrs (position != null) {
-    # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
-    position = "${position.file}:${toString position.line}";
-  };
-  passthruAttrs = removeAttrs args [ "owner" "repo" "rev" "fetchSubmodules" "forceFetchGit" "private" "githubBase" "varPrefix" ];
-  varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITHUB_PRIVATE_";
-  useFetchGit = fetchSubmodules || (leaveDotGit == true) || deepClone || forceFetchGit || (sparseCheckout != []);
-  # We prefer fetchzip in cases we don't need submodules as the hash
-  # is more stable in that case.
-  fetcher =
-    if useFetchGit then fetchgit
-    # fetchzip may not be overridable when using external tools, for example nix-prefetch
-    else if fetchzip ? override then fetchzip.override { withUnzip = false; }
-    else fetchzip;
-  privateAttrs = lib.optionalAttrs private {
-    netrcPhase = ''
-      if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
-        echo "Error: Private fetchFromGitHub requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
-        exit 1
-      fi
-      cat > netrc <<EOF
-      machine ${githubBase}
-              login ''$${varBase}USERNAME
-              password ''$${varBase}PASSWORD
-      EOF
-    '';
-    netrcImpureEnvVars = [ "${varBase}USERNAME" "${varBase}PASSWORD" ];
-  };
 
-  gitRepoUrl = "${baseUrl}.git";
+  let
 
-  fetcherArgs = (if useFetchGit
-    then {
-      inherit rev deepClone fetchSubmodules sparseCheckout; url = gitRepoUrl;
-    } // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
-    else {
-      url = "${baseUrl}/archive/${rev}.tar.gz";
-
-      passthru = {
-        inherit gitRepoUrl;
+    position = (
+      if args.meta.description or null != null then
+        builtins.unsafeGetAttrPos "description" args.meta
+      else if tag != null then
+        builtins.unsafeGetAttrPos "tag" args
+      else
+        builtins.unsafeGetAttrPos "rev" args
+    );
+    baseUrl = "https://${githubBase}/${owner}/${repo}";
+    newMeta =
+      meta
+      // {
+        homepage = meta.homepage or baseUrl;
+      }
+      // lib.optionalAttrs (position != null) {
+        # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
+        position = "${position.file}:${toString position.line}";
       };
-    }
-  ) // privateAttrs // passthruAttrs // { inherit name; };
-in
+    passthruAttrs = removeAttrs args [
+      "owner"
+      "repo"
+      "tag"
+      "rev"
+      "fetchSubmodules"
+      "forceFetchGit"
+      "private"
+      "githubBase"
+      "varPrefix"
+    ];
+    varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITHUB_PRIVATE_";
+    useFetchGit =
+      fetchSubmodules
+      || (leaveDotGit == true)
+      || deepClone
+      || forceFetchGit
+      || fetchLFS
+      || (rootDir != "")
+      || (sparseCheckout != [ ]);
+    # We prefer fetchzip in cases we don't need submodules as the hash
+    # is more stable in that case.
+    fetcher =
+      if useFetchGit then
+        fetchgit
+      # fetchzip may not be overridable when using external tools, for example nix-prefetch
+      else if fetchzip ? override then
+        fetchzip.override { withUnzip = false; }
+      else
+        fetchzip;
+    privateAttrs = lib.optionalAttrs private {
+      netrcPhase =
+        # When using private repos:
+        # - Fetching with git works using https://github.com but not with the GitHub API endpoint
+        # - Fetching a tarball from a private repo requires to use the GitHub API endpoint
+        let
+          machineName = if githubBase == "github.com" && !useFetchGit then "api.github.com" else githubBase;
+        in
+        ''
+          if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
+            echo "Error: Private fetchFromGitHub requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
+            exit 1
+          fi
+          cat > netrc <<EOF
+          machine ${machineName}
+                  login ''$${varBase}USERNAME
+                  password ''$${varBase}PASSWORD
+          EOF
+        '';
+      netrcImpureEnvVars = [
+        "${varBase}USERNAME"
+        "${varBase}PASSWORD"
+      ];
+    };
 
-fetcher fetcherArgs // { meta = newMeta; inherit rev owner repo; }
+    gitRepoUrl = "${baseUrl}.git";
+
+    fetcherArgs =
+      finalAttrs:
+      passthruAttrs
+      // (
+        if useFetchGit then
+          {
+            inherit
+              tag
+              rev
+              deepClone
+              fetchSubmodules
+              sparseCheckout
+              fetchLFS
+              ;
+            url = gitRepoUrl;
+            inherit passthru;
+            derivationArgs = {
+              inherit
+                githubBase
+                owner
+                repo
+                ;
+            };
+          }
+          // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
+        else
+          let
+            revWithTag = finalAttrs.rev;
+          in
+          {
+            # Use the API endpoint for private repos, as the archive URI doesn't
+            # support access with GitHub's fine-grained access tokens.
+            #
+            # Use the archive URI for non-private repos, as the API endpoint has
+            # relatively restrictive rate limits for unauthenticated users.
+            url =
+              if private then
+                let
+                  endpoint = "/repos/${finalAttrs.owner}/${finalAttrs.repo}/tarball/${revWithTag}";
+                in
+                if githubBase == "github.com" then
+                  "https://api.github.com${endpoint}"
+                else
+                  "https://${githubBase}/api/v3${endpoint}"
+              else
+                "${baseUrl}/archive/${revWithTag}.tar.gz";
+            extension = "tar.gz";
+            derivationArgs = {
+              inherit
+                githubBase
+                owner
+                repo
+                tag
+                ;
+              rev = fetchgit.getRevWithTag {
+                inherit (finalAttrs) tag;
+                rev = finalAttrs.revCustom;
+              };
+              revCustom = rev;
+            };
+            passthru = {
+              inherit gitRepoUrl;
+            }
+            // passthru;
+          }
+      )
+      // privateAttrs
+      // {
+        inherit name;
+        meta = newMeta;
+      };
+  in
+
+  fetcher fetcherArgs
 )

--- a/stdenv/config.nix
+++ b/stdenv/config.nix
@@ -162,6 +162,40 @@ let
         Whether to check that the `meta` attribute of derivations are correct during evaluation time.
       '';
     };
+
+    hashedMirrors = mkOption {
+      type = types.listOf types.str;
+      # This does not exist for ekapkgs yet
+      default = [ ];
+      description = ''
+        The set of content-addressed/hashed mirror URLs used by [`pkgs.fetchurl`](#sec-pkgs-fetchers-fetchurl).
+        In case `pkgs.fetchurl` can't download from the given URLs,
+        it will try the hashed mirrors based on the expected output hash.
+        See [`copy-tarballs.pl`](https://github.com/NixOS/nixpkgs/blob/a2d829eaa7a455eaa3013c45f6431e705702dd46/maintainers/scripts/copy-tarballs.pl)
+        for more details on how hashed mirrors are constructed.
+      '';
+    };
+
+    rewriteURL = mkOption {
+      type = types.functionTo (types.nullOr types.str);
+      description = ''
+        A hook to rewrite/filter URLs before they are fetched.
+
+        The function is passed the URL as a string, and is expected to return a new URL, or null if the given URL should not be attempted.
+
+        This function is applied _prior_ to resolving mirror:// URLs.
+
+        The intended use is to allow URL rewriting to insert company-internal mirrors, or work around company firewalls and similar network restrictions.
+      '';
+      default = lib.id;
+      defaultText = literalExpression "(url: url)";
+      example = literalExpression ''
+        {
+          # Use Nix like it's 2024! ;-)
+          rewriteURL = url: "https://web.archive.org/web/2024/''${url}";
+        }
+      '';
+    };
   };
 
 in {

--- a/top-level.nix
+++ b/top-level.nix
@@ -15,6 +15,8 @@ final: prev: with final; {
 
   mkManyVariants = callFromScope ./pkgs/mkManyVariants { };
 
+  fetchFromGitHub = callFromScope ./pkgs/fetchFromGitHub { };
+
   stdenvNoCC = stdenv.override (
     { cc = null; hasCC = false; }
 
@@ -298,13 +300,7 @@ final: prev: with final; {
   docbook_xsl = docbook-xsl-nons;
   docbook_xsl_ns = docbook-xsl-ns;
 
-  fetchgit = (callPackage ./build-support/fetchgit {
-    git = buildPackages.git;
-    cacert = buildPackages.cacert;
-    git-lfs = buildPackages.git-lfs;
-  }) // { # fetchgit is a function, so we use // instead of passthru.
-    tests = pkgs.tests.fetchgit;
-  };
+  fetchgit = callFromScope ./build-support/fetchgit { };
 
   fetchFromGitLab = callPackage ./build-support/fetchgitlab { };
 
@@ -335,6 +331,7 @@ final: prev: with final; {
       lib.makeOverridable (import ./build-support/fetchurl) {
         inherit lib stdenvNoCC buildPackages;
         inherit cacert;
+        inherit config;
         curl = buildPackages.curlMinimal.override (old: rec {
           # break dependency cycles
           fetchurl = stdenv.fetchurlBoot;


### PR DESCRIPTION
Adapted from https://github.com/NixOS/nixpkgs/pull/316668. But don't make it opt-in to have default names of sources be more descriptive. Instead just give them descriptive names unless passed an explicit `name` attr.

In the spirit of https://github.com/NixOS/rfcs/pull/171