### PR TITLE
autoconf: remove m4 as buildInput

### DIFF
--- a/pkgs/autoconf/default.nix
+++ b/pkgs/autoconf/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ m4 perl texinfo ];
-  buildInputs = [ m4 ];
+
   postBuild = "
     make html
   ";


### PR DESCRIPTION
In theory this shouldn't be needed 