### PR TITLE
fetchgit: don't respect config.gitConfig

### DIFF
--- a/build-support/fetchgit/default.nix
+++ b/build-support/fetchgit/default.nix
@@ -95,8 +95,6 @@ lib.makeOverridable (
           fetchTags ? false,
           # make this subdirectory the root of the result
           rootDir ? "",
-          # GIT_CONFIG_GLOBAL (as a file)
-          gitConfigFile ? config.gitConfigFile,
           # Additional stdenvNoCC.mkDerivation arguments.
           # It is typically for derived fetchers to pass down additional arguments,
           # and the specified arguments have lower precedence than other mkDerivation arguments.
@@ -169,7 +167,6 @@ lib.makeOverridable (
               postFetch
               fetchTags
               rootDir
-              gitConfigFile
               ;
             inherit tag;
             revCustom = rev;

--- a/docs/major-differences-nixpkgs.md
+++ b/docs/major-differences-nixpkgs.md
@@ -4,4 +4,9 @@ Although there is desire to keep as aligned with Nixpkgs as possible, Ekapkgs
 isn't obligated to retain poor UX paradigms either. In that vein, the following
 changes differ significantly from whath one would expct with Nixpkgs.
 
+## Evaluation behavior
+
 - `~/.config/nix` is no longer respected for `config` or `overlays`
+- `config.gitConfig` and `config.gitConfigFile` were removed
+  - Globally altering git behavior should be done at the machine level
+


### PR DESCRIPTION
This undoes part of https://github.com/NixOS/nixpkgs/pull/443788.

Personally, I don't think it's the responsibility of the package set to handle redirects/mirrors. Instead that should be the responsibility of the machine configuration. I feel like this has more potential to cause harm than good.

closes #32