### PR TITLE
cmake: change default to v4

### DIFF
--- a/pkgs-many/cmake/default.nix
+++ b/pkgs-many/cmake/default.nix
@@ -3,6 +3,6 @@
 mkManyVariants {
   variants = ./versions.nix;
   aliases = { };
-  defaultSelector = (p: p.v3);
+  defaultSelector = (p: p.v4);
   genericBuilder = ./package.nix;
 }


### PR DESCRIPTION
Since we are now based on master nixpkgs we can safely move to cmake v4

```fish
❯ nom-build -A stdenv -A python -A cmake -A boost -A isl -A git --show-trace
fetching git input 'git+https://github.com/ekala-project/nix-lib.git'
Finished at 18:31:57 after 12s
/nix/store/2ghvh97pnk7avkc526h79dja5n66ix8p-stdenv-linux
/nix/store/my45q0j68rikzrrma1ml677lp15j0zm7-python3-3.13.9
/nix/store/f7ic0sdj7477c8jp63847qqrmr4h7j3h-cmake-4.2.0
/nix/store/6dv5cwi2pg8q98mvwg1yhbcssaa4s48q-boost-1.86.0
/nix/store/m0xfnp8p5chq1d2gqazhbfrc694y7vpx-isl-0.20
/nix/store/v0l5943aw7bb4qy2c1gn85nw6dx9frpy-git-2.51.2
```