### PR TITLE
Fix cross compilation

### DIFF
--- a/pkgs/libiberty/default.nix
+++ b/pkgs/libiberty/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  buildPackages,
+  staticBuild ? stdenv.hostPlatform.isStatic,
+}:
+
+let
+  inherit (buildPackages.buildPackages) gcc;
+in
+
+stdenv.mkDerivation {
+  pname = "libiberty";
+  version = "${gcc.cc.version}";
+
+  inherit (gcc.cc) src;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  postUnpack = "sourceRoot=\${sourceRoot}/libiberty";
+
+  # needed until config scripts are updated to not use /usr/bin/uname on FreeBSD native
+  # updateAutotoolsGnuConfigScriptsHook doesn't seem to work here
+  postPatch = ''
+    substituteInPlace ../config.guess --replace-fail /usr/bin/uname uname
+  '';
+
+  configureFlags = [ "--enable-install-libiberty" ] ++ lib.optional (!staticBuild) "--enable-shared";
+
+  postInstall = lib.optionalString (!staticBuild) ''
+    cp pic/libiberty.a $out/lib*/libiberty.a
+  '';
+
+  meta = with lib; {
+    homepage = "https://gcc.gnu.org/";
+    license = licenses.lgpl2;
+    description = "Collection of subroutines used by various GNU programs";
+    maintainers = [ ];
+    platforms = platforms.unix;
+  };
+}

--- a/stdenv/cross/default.nix
+++ b/stdenv/cross/default.nix
@@ -1,0 +1,139 @@
+{
+  lib,
+  localSystem,
+  crossSystem,
+  config,
+  overlays,
+  crossOverlays ? [ ],
+}:
+
+let
+  bootStages = import ../. {
+    inherit lib localSystem overlays;
+
+    crossSystem = localSystem;
+    crossOverlays = [ ];
+
+    # Ignore custom stdenvs when cross compiling for compatibility
+    # Use replaceCrossStdenv instead.
+    config = removeAttrs config [ "replaceStdenv" ];
+  };
+
+in
+lib.init bootStages
+++ [
+
+  # Regular native packages
+  (
+    somePrevStage:
+    lib.last bootStages somePrevStage
+    // {
+      # It's OK to change the built-time dependencies
+      allowCustomOverrides = true;
+    }
+  )
+
+  # Build tool Packages
+  (vanillaPackages: {
+    inherit config overlays;
+    selfBuild = false;
+    stdenv =
+      assert vanillaPackages.stdenv.buildPlatform == localSystem;
+      assert vanillaPackages.stdenv.hostPlatform == localSystem;
+      assert vanillaPackages.stdenv.targetPlatform == localSystem;
+      vanillaPackages.stdenv.override { targetPlatform = crossSystem; };
+    # It's OK to change the built-time dependencies
+    allowCustomOverrides = true;
+  })
+
+  # Run Packages
+  (
+    buildPackages:
+    let
+      adaptStdenv = if crossSystem.isStatic then buildPackages.stdenvAdapters.makeStatic else lib.id;
+      stdenvNoCC = adaptStdenv (
+        buildPackages.stdenv.override (old: rec {
+          buildPlatform = localSystem;
+          hostPlatform = crossSystem;
+          targetPlatform = crossSystem;
+
+          # Prior overrides are surely not valid as packages built with this run on
+          # a different platform, and so are disabled.
+          overrides = _: _: { };
+          extraBuildInputs = [ ]; # Old ones run on wrong platform
+          allowedRequisites = null;
+
+          cc = null;
+          hasCC = false;
+
+          extraNativeBuildInputs =
+            old.extraNativeBuildInputs
+            ++ lib.optionals (hostPlatform.isLinux && !buildPlatform.isLinux) [ buildPackages.patchelf ]
+            ++ lib.optional (
+              let
+                f =
+                  p:
+                  !p.isx86
+                  || builtins.elem p.libc [
+                    "musl"
+                    "wasilibc"
+                    "relibc"
+                  ]
+                  || p.isiOS
+                  || p.isGenode;
+              in
+              f hostPlatform && !(f buildPlatform)
+            ) buildPackages.updateAutotoolsGnuConfigScriptsHook;
+        })
+      );
+    in
+    {
+      inherit config;
+      overlays = overlays ++ crossOverlays;
+      selfBuild = false;
+      inherit stdenvNoCC;
+      stdenv =
+        let
+          inherit (stdenvNoCC) hostPlatform targetPlatform;
+          baseStdenv = stdenvNoCC.override {
+            # Old ones run on wrong platform
+            extraBuildInputs = lib.optionals hostPlatform.isDarwin [
+              buildPackages.targetPackages.apple-sdk
+            ];
+
+            hasCC = !stdenvNoCC.targetPlatform.isGhcjs;
+
+            cc =
+              if crossSystem.useiOSPrebuilt or false then
+                buildPackages.darwin.iosSdkPkgs.clang
+              else if crossSystem.useAndroidPrebuilt or false then
+                buildPackages."androidndkPkgs_${crossSystem.androidNdkVersion}".clang
+              else if
+                targetPlatform.isGhcjs
+              # Need to use `throw` so tryEval for splicing works, ugh.  Using
+              # `null` or skipping the attribute would cause an eval failure
+              # `tryEval` wouldn't catch, wrecking accessing previous stages
+              # when there is a C compiler and everything should be fine.
+              then
+                throw "no C compiler provided for this platform"
+              else if crossSystem.isDarwin then
+                buildPackages.llvmPackages.systemLibcxxClang
+              else if crossSystem.useLLVM or false then
+                buildPackages.llvmPackages.clang
+              else if crossSystem.useZig or false then
+                buildPackages.zig.cc
+              else if crossSystem.useArocc or false then
+                buildPackages.arocc
+              else
+                buildPackages.gcc;
+
+          };
+        in
+        if config ? replaceCrossStdenv then
+          config.replaceCrossStdenv { inherit buildPackages baseStdenv; }
+        else
+          baseStdenv;
+    }
+  )
+
+]

--- a/top-level.nix
+++ b/top-level.nix
@@ -524,6 +524,20 @@ with final;
   patchelf = callPackage ./pkgs/patchelf { };
   patchelfUnstable = lowPrio (callPackage ./pkgs/patchelf/unstable.nix { });
 
+  # These are used when building compiler-rt / libgcc, prior to building libc.
+  preLibcHeaders =
+    let
+      inherit (stdenv.hostPlatform) libc;
+    in
+    if stdenv.hostPlatform.isMinGW then
+      windows.mingw_w64_headers or fallback
+    else if libc == "nblibc" then
+      netbsd.headers
+    else if libc == "cygwin" then
+      cygwin.newlib-cygwin-headers
+    else
+      null;
+
   # TODO(corepkgs): This should be moved into unixtools
   procps = if stdenv.hostPlatform.isLinux then procps-ng else unixtools.procps;
 

--- a/top-level.nix
+++ b/top-level.nix
@@ -1174,6 +1174,16 @@ with final;
   texinfo = texinfo7;
   texinfoInteractive = texinfo.override { interactive = true; };
 
+  # TODO(corepkgs): remove hack
+  threads =
+    lib.optionalAttrs (stdenv.hostPlatform.isMinGW && !(stdenv.hostPlatform.useLLVM or false))
+      {
+        # other possible values: win32 or posix
+        model = "mcf";
+        # For win32 or posix set this to null
+        package = windows.mcfgthreads;
+      };
+
   # On non-GNU systems we need GNU Gettext for libintl.
   libintl = if stdenv.hostPlatform.libc != "glibc" then gettext else null;
 

--- a/top-level.nix
+++ b/top-level.nix
@@ -547,7 +547,7 @@ with final;
 
   default-gcc-version = 14;
   gcc = pkgs.${"gcc${toString default-gcc-version}"};
-  gccFun = callPackage ./pkgs/gcc { };
+  gccFun = callPackage ./pkgs/gcc;
   gcc-unwrapped = gcc.cc;
   libgcc = stdenv.cc.cc.libgcc or null;
 


### PR DESCRIPTION
Still building, but seems to be doing fine and eval is very much fixed.

```
[17:42:34] jon@jon-desktop /home/jon/projects/core-pkgs (fix-cross)
$ nix-instantiate -A pkgsCross.aarch64-multiplatform.stdenv
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
/nix/store/1k2yy8554qsppirn8sa4mlgg9bmwx74b-stdenv-linux.drv
```