### PR TITLE
treewide: purge maintainers field

### DIFF
--- a/build-support/trivial-builders/test/writeClosure-union.nix
+++ b/build-support/trivial-builders/test/writeClosure-union.nix
@@ -11,9 +11,7 @@ runCommandLocal "test-trivial-builders-writeClosure-union"
     closures = lib.mapAttrs (n: v: writeClosure [ v ]) samples;
     collectiveClosure = writeClosure (lib.attrValues samples);
     inherit samples;
-    meta.maintainers = with lib.maintainers; [
-      ShamrockLee
-    ];
+    meta.maintainers = [ ];
   }
   ''
     set -eu -o pipefail

--- a/pkgs-many/libmicrohttpd/generic.nix
+++ b/pkgs-many/libmicrohttpd/generic.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       homepage = "https://www.gnu.org/software/libmicrohttpd/";
 
-      maintainers = with maintainers; [ ];
+      maintainers = [ ];
       platforms = platforms.unix;
     }
     // meta;

--- a/pkgs/alsa-topology-conf/default.nix
+++ b/pkgs/alsa-topology-conf/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     '';
 
     license = licenses.bsd3;
-    maintainers = [ maintainers.roastiek ];
+    maintainers = [ ];
     platforms = platforms.linux ++ platforms.freebsd;
   };
 }

--- a/pkgs/alsa-ucm-conf/default.nix
+++ b/pkgs/alsa-ucm-conf/default.nix
@@ -51,10 +51,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
 
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [
-      roastiek
-      mvs
-    ];
+    maintainers = [ ];
 
     platforms = lib.platforms.linux ++ lib.platforms.freebsd;
   };

--- a/pkgs/argp-standalone/default.nix
+++ b/pkgs/argp-standalone/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/argp-standalone/argp-standalone";
     description = "Standalone version of arguments parsing functions from Glibc";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ amar1729 ];
+    maintainers = [ ];
     license = licenses.lgpl21Plus;
   };
 }

--- a/pkgs/auto-patchelf/default.nix
+++ b/pkgs/auto-patchelf/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation {
     mainProgram = "auto-patchelf";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ Scrumplex ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/bash-completion/default.nix
+++ b/pkgs/bash-completion/default.nix
@@ -77,6 +77,6 @@ stdenv.mkDerivation rec {
     description = "Programmable completion for the bash shell";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ philiptaron ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/bpftools/default.nix
+++ b/pkgs/bpftools/default.nix
@@ -86,6 +86,6 @@ stdenv.mkDerivation rec {
       licenses.bsd2
     ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ thoughtpolice ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/catch2/default.nix
+++ b/pkgs/catch2/default.nix
@@ -24,9 +24,7 @@ stdenv.mkDerivation rec {
     description = "Multi-paradigm automated test framework for C++ and Objective-C (and, maybe, C)";
     homepage = "http://catch-lib.net";
     license = licenses.boost;
-    maintainers = with maintainers; [
-      edwtjo
-    ];
+    maintainers = [ ];
     platforms = with platforms; unix ++ windows;
   };
 }

--- a/pkgs/catch2_3/default.nix
+++ b/pkgs/catch2_3/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/catchorg/Catch2";
     changelog = "https://github.com/catchorg/Catch2/blob/${src.tag}/docs/release-notes.md";
     license = lib.licenses.boost;
-    maintainers = with lib.maintainers; [ dotlambda ];
+    maintainers = [ ];
     platforms = with lib.platforms; unix ++ windows;
   };
 }

--- a/pkgs/cmocka/default.nix
+++ b/pkgs/cmocka/default.nix
@@ -56,8 +56,6 @@ stdenv.mkDerivation rec {
     homepage = "https://cmocka.org/";
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [
-      kragniz
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/cracklib/default.nix
+++ b/pkgs/cracklib/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Password checking library";
     changelog = "https://github.com/cracklib/cracklib/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [ lovek323 ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/dns-root-data/default.nix
+++ b/pkgs/dns-root-data/default.nix
@@ -30,10 +30,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://www.iana.org/domains/root/files";
     description = "DNS root data including root hints and DNSSEC root trust anchor + key";
-    maintainers = with maintainers; [
-      fpletz
-      vcunat
-    ];
+    maintainers = [ ];
     license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/duktape/default.nix
+++ b/pkgs/duktape/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://duktape.org/";
     downloadPage = "https://duktape.org/download.html";
     license = licenses.mit;
-    maintainers = [ maintainers.fgaz ];
+    maintainers = [ ];
     mainProgram = "duk";
     platforms = platforms.all;
   };

--- a/pkgs/elfutils/default.nix
+++ b/pkgs/elfutils/default.nix
@@ -152,6 +152,6 @@ stdenv.mkDerivation rec {
       lgpl3Plus
       gpl3Plus
     ];
-    maintainers = with maintainers; [ r-burns ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/ell/default.nix
+++ b/pkgs/ell/default.nix
@@ -64,9 +64,6 @@ stdenv.mkDerivation rec {
     changelog = "https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?h=${version}";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [
-      mic92
-      dtzWill
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/elogind/default.nix
+++ b/pkgs/elogind/default.nix
@@ -157,6 +157,6 @@ stdenv.mkDerivation rec {
     description = "systemd project's 'logind', extracted to a standalone package";
     platforms = platforms.linux; # probably more
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ nh2 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/eudev/default.nix
+++ b/pkgs/eudev/default.nix
@@ -85,9 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/eudev-project/eudev/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      raskin
-    ];
+    maintainers = [ ];
     pkgConfigModules = [
       "libudev"
       "udev"

--- a/pkgs/fusePackages/common.nix
+++ b/pkgs/fusePackages/common.nix
@@ -140,9 +140,7 @@ stdenv.mkDerivation rec {
       gpl2Only
       lgpl21Only
     ];
-    maintainers = with lib.maintainers; [
-      oxalica
-    ];
+    maintainers = [ ];
     outputsToInstall = [ "bin" ];
   };
 }

--- a/pkgs/gnupg/default.nix
+++ b/pkgs/gnupg/default.nix
@@ -210,10 +210,7 @@ stdenv.mkDerivation rec {
       frontend applications and libraries are available.  Version 2 of GnuPG
       also provides support for S/MIME.
     '';
-    maintainers = with maintainers; [
-      fpletz
-      sgo
-    ];
+    maintainers = [ ];
     platforms = platforms.all;
     mainProgram = "gpg";
   };

--- a/pkgs/gobject-introspection/unwrapped.nix
+++ b/pkgs/gobject-introspection/unwrapped.nix
@@ -177,10 +177,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Middleware layer between C libraries and language bindings";
     homepage = "https://gi.readthedocs.io/";
-    maintainers = with maintainers; [
-      lovek323
-      artturin
-    ];
+    maintainers = [ ];
     teams = [ teams.gnome ];
     pkgConfigModules = [ "gobject-introspection-1.0" ];
     platforms = platforms.unix;

--- a/pkgs/hidapi/default.nix
+++ b/pkgs/hidapi/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Library for communicating with USB and Bluetooth HID devices";
     homepage = "https://github.com/libusb/hidapi";
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = [ ];
     # You can choose between GPLv3, BSD or HIDAPI license (even more liberal)
     license = with licenses; [
       bsd3 # or

--- a/pkgs/intltool/default.nix
+++ b/pkgs/intltool/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     description = "Translation helper tool";
     homepage = "https://launchpad.net/intltool/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ raskin ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/iproute2/default.nix
+++ b/pkgs/iproute2/default.nix
@@ -109,9 +109,6 @@ stdenv.mkDerivation rec {
     description = "Collection of utilities for controlling TCP/IP networking and traffic control in Linux";
     platforms = platforms.linux;
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [
-      fpletz
-      globin
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/iptables/default.nix
+++ b/pkgs/iptables/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.netfilter.org/projects/iptables/index.html";
     platforms = platforms.linux;
     mainProgram = "iptables";
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = [ ];
     license = licenses.gpl2Plus;
     downloadPage = "https://www.netfilter.org/projects/iptables/files/";
   };

--- a/pkgs/jq/default.nix
+++ b/pkgs/jq/default.nix
@@ -126,12 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://jqlang.github.io/jq/";
     downloadPage = "https://jqlang.github.io/jq/download/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      raskin
-      artturin
-      ncfavier
-      jk
-    ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "jq";
   };

--- a/pkgs/kbd/default.nix
+++ b/pkgs/kbd/default.nix
@@ -136,6 +136,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Linux keyboard tools and keyboard maps";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ davidak ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/kmod/default.nix
+++ b/pkgs/kmod/default.nix
@@ -126,6 +126,6 @@ stdenv.mkDerivation rec {
       gpl2Plus
     ]; # GPLv2+ for tools
     platforms = platforms.linux;
-    maintainers = with maintainers; [ artturin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/ldns/default.nix
+++ b/pkgs/ldns/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     description = "Library with the aim of simplifying DNS programming in C";
     homepage = "https://www.nlnetlabs.nl/projects/ldns/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ dtzWill ];
+    maintainers = [ ];
     mainProgram = "drill";
     platforms = platforms.unix;
   };

--- a/pkgs/lerc/default.nix
+++ b/pkgs/lerc/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C++ library for Limited Error Raster Compression";
     homepage = "https://github.com/esri/lerc";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ dotlambda ];
+    maintainers = [ ];
     pkgConfigModules = [ "Lerc" ];
   };
 })

--- a/pkgs/libbpf/0.x.nix
+++ b/pkgs/libbpf/0.x.nix
@@ -58,12 +58,7 @@ stdenv.mkDerivation rec {
       lgpl21 # or
       bsd2
     ];
-    maintainers = with maintainers; [
-      thoughtpolice
-      vcunat
-      saschagrunert
-      martinetd
-    ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/libbpf/default.nix
+++ b/pkgs/libbpf/default.nix
@@ -66,12 +66,7 @@ stdenv.mkDerivation rec {
       lgpl21 # or
       bsd2
     ];
-    maintainers = with maintainers; [
-      thoughtpolice
-      vcunat
-      saschagrunert
-      martinetd
-    ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/libdeflate/default.nix
+++ b/pkgs/libdeflate/default.nix
@@ -43,9 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ebiggers/libdeflate";
     changelog = "https://github.com/ebiggers/libdeflate/blob/v${finalAttrs.version}/NEWS.md";
     platforms = platforms.unix ++ platforms.windows;
-    maintainers = with maintainers; [
-      kaction
-    ];
+    maintainers = [ ];
     pkgConfigModules = [ "libdeflate" ];
   };
 })

--- a/pkgs/libfido2/default.nix
+++ b/pkgs/libfido2/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/Yubico/libfido2";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/libjpeg_turbo/default.nix
+++ b/pkgs/libjpeg_turbo/default.nix
@@ -117,10 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
       "libjpeg"
       "libturbojpeg"
     ];
-    maintainers = with lib.maintainers; [
-      vcunat
-      kamadorueda
-    ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/libnftnl/default.nix
+++ b/pkgs/libnftnl/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://netfilter.org/projects/libnftnl/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/libnl/default.nix
+++ b/pkgs/libnl/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.infradead.org/~tgr/libnl/";
     description = "Linux Netlink interface library suite";
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/libpcap/default.nix
+++ b/pkgs/libpcap/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
     description = "Packet Capture Library";
     mainProgram = "pcap-config";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = [ ];
     license = licenses.bsd3;
   };
 }

--- a/pkgs/libpfm/default.nix
+++ b/pkgs/libpfm/default.nix
@@ -47,10 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
       (PMU) of modern processors.
     '';
     license = licenses.gpl2;
-    maintainers = with maintainers; [
-      pierron
-      t4ccer
-    ];
+    maintainers = [ ];
     platforms = platforms.linux ++ platforms.windows;
   };
 })

--- a/pkgs/libpng/default.nix
+++ b/pkgs/libpng/default.nix
@@ -61,6 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
       "libpng16"
     ];
     platforms = platforms.all;
-    maintainers = with maintainers; [ vcunat ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/libpwquality/default.nix
+++ b/pkgs/libpwquality/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
       # or
       gpl2Plus
     ];
-    maintainers = with maintainers; [ jk ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/libseccomp/default.nix
+++ b/pkgs/libseccomp/default.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation rec {
       "sparc-linux"
       "sparc64-linux"
     ];
-    maintainers = with maintainers; [ thoughtpolice ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/libsodium/default.nix
+++ b/pkgs/libsodium/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Modern and easy-to-use crypto library";
     homepage = "https://doc.libsodium.org/";
     license = licenses.isc;
-    maintainers = with maintainers; [ raskin ];
+    maintainers = [ ];
     pkgConfigModules = [ "libsodium" ];
     platforms = platforms.all;
   };

--- a/pkgs/libsystemtap/default.nix
+++ b/pkgs/libsystemtap/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation {
     license = licenses.bsd3;
     platforms = elfutils.meta.platforms or platforms.unix;
     badPlatforms = elfutils.meta.badPlatforms or [ ];
-    maintainers = [ lib.maintainers.workflow ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/libtapi/default.nix
+++ b/pkgs/libtapi/default.nix
@@ -162,9 +162,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/apple-oss-distributions/tapi/";
     license = lib.licenses.ncsa;
     mainProgram = "tapi";
-    maintainers = with lib.maintainers; [
-      reckenrode
-    ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/libtpms/default.nix
+++ b/pkgs/libtpms/default.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     description = "Library for software emulation of a Trusted Platform Module (TPM 1.2 and TPM 2.0)";
     homepage = "https://github.com/stefanberger/libtpms";
     license = licenses.bsd3;
-    maintainers = [ maintainers.baloo ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/liburing/default.nix
+++ b/pkgs/liburing/default.nix
@@ -56,9 +56,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/axboe/liburing";
     license = licenses.lgpl21;
     platforms = platforms.linux;
-    maintainers = with maintainers; [
-      thoughtpolice
-      nickcao
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/libusb1/default.nix
+++ b/pkgs/libusb1/default.nix
@@ -74,9 +74,6 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.all;
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [
-      prusnak
-      logger
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/libwebp/default.nix
+++ b/pkgs/libwebp/default.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
     homepage = "https://developers.google.com/speed/webp/";
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ajs124 ];
+    maintainers = [ ];
     pkgConfigModules = [
       # configure_pkg_config() calls for these are unconditional
       "libwebp"

--- a/pkgs/lvm2/common.nix
+++ b/pkgs/lvm2/common.nix
@@ -242,9 +242,6 @@ stdenv.mkDerivation rec {
       bsd2
       lgpl21
     ];
-    maintainers = with maintainers; [
-      raskin
-      ajs124
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/lz4/default.nix
+++ b/pkgs/lz4/default.nix
@@ -75,6 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = platforms.all;
     mainProgram = "lz4";
-    maintainers = [ maintainers.tobim ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/mdadm/default.nix
+++ b/pkgs/mdadm/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
     homepage = "https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git";
     license = licenses.gpl2Plus;
     mainProgram = "mdadm";
-    maintainers = with maintainers; [ ekleog ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/musl-fts/default.nix
+++ b/pkgs/musl-fts/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     description = "Implementation of fts(3) for musl-libc";
     platforms = platforms.linux;
     license = licenses.bsd3;
-    maintainers = [ maintainers.pjjw ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/musl-obstack/default.nix
+++ b/pkgs/musl-obstack/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     description = "Extraction of the obstack functions and macros from GNU libiberty for use with musl-libc";
     platforms = platforms.unix;
     license = licenses.lgpl21Plus;
-    maintainers = [ maintainers.pjjw ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/nasm/default.nix
+++ b/pkgs/nasm/default.nix
@@ -40,9 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.nasm.us/";
     description = "80x86 and x86-64 assembler designed for portability and modularity";
     platforms = platforms.unix;
-    maintainers = with maintainers; [
-      pSub
-    ];
+    maintainers = [ ];
     mainProgram = "nasm";
     license = licenses.bsd2;
   };

--- a/pkgs/nettle/generic.nix
+++ b/pkgs/nettle/generic.nix
@@ -71,6 +71,6 @@ stdenv.mkDerivation {
     homepage = "https://www.lysator.liu.se/~nisse/nettle/";
 
     platforms = platforms.all;
-    maintainers = [ maintainers.vcunat ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/oniguruma/default.nix
+++ b/pkgs/oniguruma/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "Regular expressions library";
     mainProgram = "onig-config";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ artturin ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/pcsclite/default.nix
+++ b/pkgs/pcsclite/default.nix
@@ -126,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://salsa.debian.org/rousseau/PCSC/-/blob/${finalAttrs.version}/ChangeLog";
     license = lib.licenses.bsd3;
     mainProgram = "pcscd";
-    maintainers = [ lib.maintainers.anthonyroussel ];
+    maintainers = [ ];
     pkgConfigModules = [ "libpcsclite" ];
     platforms = lib.platforms.unix;
     broken = !(polkitSupport -> dbusSupport) || !(systemdSupport -> dbusSupport);

--- a/pkgs/qrencode/default.nix
+++ b/pkgs/qrencode/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
       QR Code images in various formats.
     '';
     license = lib.licenses.lgpl21Plus;
-    maintainers = [ lib.maintainers.mdaniels5757 ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "qrencode";
   };

--- a/pkgs/shared-mime-info/default.nix
+++ b/pkgs/shared-mime-info/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     homepage = "http://freedesktop.org/wiki/Software/shared-mime-info";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = [ maintainers.mimame ];
+    maintainers = [ ];
     teams = [ teams.freedesktop ];
     mainProgram = "update-mime-database";
   };

--- a/pkgs/socat/default.nix
+++ b/pkgs/socat/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.dest-unreach.org/socat/";
     platforms = platforms.unix;
     license = with licenses; [ gpl2Only ];
-    maintainers = with maintainers; [ ryan4yin ];
+    maintainers = [ ];
     mainProgram = "socat";
   };
 }

--- a/pkgs/sourceHighlight/default.nix
+++ b/pkgs/sourceHighlight/default.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/src-highlite/";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    maintainers = [ ];
   };
 }
 // lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {

--- a/pkgs/spdlog/default.nix
+++ b/pkgs/spdlog/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/gabime/spdlog";
     changelog = "https://github.com/gabime/spdlog/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ obadz ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/swtpm/default.nix
+++ b/pkgs/swtpm/default.nix
@@ -144,7 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Libtpms-based TPM emulator";
     homepage = "https://github.com/stefanberger/swtpm";
     license = licenses.bsd3;
-    maintainers = [ maintainers.baloo ];
+    maintainers = [ ];
     mainProgram = "swtpm";
     platforms = platforms.all;
   };

--- a/pkgs/tcb/default.nix
+++ b/pkgs/tcb/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation {
     homepage = "https://www.openwall.com/tcb/";
     license = licenses.bsd3;
     platforms = systems.inspect.patterns.isGnu;
-    maintainers = with maintainers; [ izorkin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tpm2-tss/default.nix
+++ b/pkgs/tpm2-tss/default.nix
@@ -171,9 +171,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/tpm2-software/tpm2-tss";
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [
-      baloo
-      scottstephens
-    ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/trousers/default.nix
+++ b/pkgs/trousers/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     mainProgram = "tcsd";
     homepage = "https://trousers.sourceforge.net/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.ak ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/udevCheckHook/default.nix
+++ b/pkgs/udevCheckHook/default.nix
@@ -20,6 +20,6 @@ makeSetupHook {
   };
   meta = {
     description = "Check validity of udev rules in outputs";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [ ];
   };
 } ./hook.sh

--- a/pkgs/unbound/default.nix
+++ b/pkgs/unbound/default.nix
@@ -222,7 +222,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Validating, recursive, and caching DNS resolver";
     license = lib.licenses.bsd3;
     homepage = "https://www.unbound.net";
-    maintainers = with lib.maintainers; [ Scrumplex ];
+    maintainers = [ ];
     platforms = with lib.platforms; unix ++ windows;
   };
 })

--- a/pkgs/vala/default.nix
+++ b/pkgs/vala/default.nix
@@ -115,10 +115,7 @@ let
         homepage = "https://vala.dev";
         license = licenses.lgpl21Plus;
         platforms = platforms.unix;
-        maintainers = with maintainers; [
-          antono
-          jtojnar
-        ];
+        maintainers = [ ];
         teams = [ teams.pantheon ];
       };
     }

--- a/pkgs/valgrind/default.nix
+++ b/pkgs/valgrind/default.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
 
     license = lib.licenses.gpl3Plus;
 
-    maintainers = [ lib.maintainers.eelco ];
+    maintainers = [ ];
     platforms =
       with lib.platforms;
       lib.intersectLists (x86 ++ power ++ s390x ++ armv7 ++ aarch64 ++ mips ++ riscv64) (

--- a/pkgs/woff2/default.nix
+++ b/pkgs/woff2/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     description = "Webfont compression reference code";
     homepage = "https://github.com/google/woff2";
     license = licenses.mit;
-    maintainers = [ maintainers.hrdinka ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/zeromq/default.nix
+++ b/pkgs/zeromq/default.nix
@@ -117,7 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Intelligent Transport Layer";
     license = lib.licenses.mpl20;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ fpletz ];
+    maintainers = [ ];
     pkgConfigModules = [ "libzmq" ];
   };
 })

--- a/python/pkgs/markdown/default.nix
+++ b/python/pkgs/markdown/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     mainProgram = "markdown_py";
     homepage = "https://github.com/Python-Markdown/markdown";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ dotlambda ];
+    maintainers = [ ];
   };
 }

--- a/python/pkgs/meson-python/default.nix
+++ b/python/pkgs/meson-python/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     description = "Meson Python build backend (PEP 517)";
     homepage = "https://github.com/mesonbuild/meson-python";
     license = [ lib.licenses.mit ];
-    maintainers = with lib.maintainers; [ doronbehar ];
+    maintainers = [ ];
     teams = [ lib.teams.python ];
   };
 }

--- a/python/pkgs/pyelftools/default.nix
+++ b/python/pkgs/pyelftools/default.nix
@@ -46,10 +46,7 @@ buildPythonPackage rec {
       # See elftools/construct/{LICENSE,README} in the source code.
       mit
     ];
-    maintainers = with lib.maintainers; [
-      igsha
-      pamplemousse
-    ];
+    maintainers = [ ];
     mainProgram = "readelf.py";
   };
 }

--- a/python/pkgs/smartypants/default.nix
+++ b/python/pkgs/smartypants/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/leohemsted/smartypants.py";
     changelog = "https://github.com/leohemsted/smartypants.py/blob/v${version}/CHANGES.rst";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ dotlambda ];
+    maintainers = [ ];
     mainProgram = "smartypants";
   };
 }

--- a/python/pkgs/typogrify/default.nix
+++ b/python/pkgs/typogrify/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     description = "Filters to enhance web typography, including support for Django & Jinja templates";
     homepage = "https://github.com/justinmayer/typogrify";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ dotlambda ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
Ekapkgs will be moving away from maintainer ship expressed in the package expression, and instead delegate this to an out-of-tree tool which can be curated independently.