### PR TITLE
fetchurl: do not use __structuredAttrs

### DIFF
--- a/build-support/fetchurl/default.nix
+++ b/build-support/fetchurl/default.nix
@@ -240,7 +240,7 @@ lib.extendMkDerivation {
 
     derivationArgs
     // {
-      __structuredAttrs = true;
+      __structuredAttrs = false;
 
       name =
         if finalAttrs.pname or null != null && finalAttrs.version or null != null then


### PR DESCRIPTION
Before:
```
error: builder for '/nix/store/7hfk505jf2qqflrnl9h3iqh8hzdzv3mp-spdlog-1.16.0-github-source.drv' failed with exit code 1;
       last 14 log lines:
       > structuredAttrs is enabled
       > structuredAttrs is enabled
       >
       > trying https://github.com/gabime/spdlog/archive/refs/tags/v1.16.0.tar.gz
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
       > curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
       > More details here: https://curl.se/docs/sslcerts.html
       >
       > curl failed to verify the legitimacy of the server and therefore could not
       > establish a secure connection to it. To learn more about this situation and
       > how to fix it, please visit the webpage mentioned above.
       > error: cannot download spdlog-1.16.0-github-source from any mirror
       For full logs, run:
         nix log /nix/store/7hfk505jf2qqflrnl9h3iqh8hzdzv3mp-spdlog-1.16.0-github-source.drv
```

After:
```
$ nix-build -A spdlog.src
this derivation will be built:
  /nix/store/rz9f5zgnngka58ajbbams3xwsa19119z-spdlog-1.16.0-github-source.drv
building '/nix/store/rz9f5zgnngka58ajbbams3xwsa19119z-spdlog-1.16.0-github-source.drv'...

trying https://github.com/gabime/spdlog/archive/refs/tags/v1.16.0.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 280382 100 280382   0     0 389149     0  --:--:-- --:--:-- --:--:-- 389149
unpacking source archive /build/download.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/rz9f5zgnngka58ajbbams3xwsa19119z-spdlog-1.16.0-github-source.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-VB82cNfpJlamUjrQFYElcy0CXAbkPqZkD5zhuLeHLzs=
```                     