### PR TITLE
spdlog: 1.15.3 -> 1.16.0

### DIFF
--- a/pkgs/spdlog/default.nix
+++ b/pkgs/spdlog/default.nix
@@ -16,23 +16,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "spdlog";
-  version = "1.15.3";
+  version = "1.16.0";
 
   src = fetchFromGitHub {
     owner = "gabime";
     repo = "spdlog";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0rOR9G2Y4Z4OBZtUHxID0s1aXN9ejodHrurlVCA0pIo=";
+    hash = "sha256-VB82cNfpJlamUjrQFYElcy0CXAbkPqZkD5zhuLeHLzs=";
   };
-
-  patches = [
-    # https://github.com/gabime/spdlog/pull/3451
-    (fetchpatch {
-      name = "catch2-3.9.0-compat.patch";
-      url = "https://github.com/gabime/spdlog/commit/3edc8036dbf3c7cdf0e460a913ae294c87ae90dc.patch";
-      hash = "sha256-0XtNaAvDGpSTtQZjxmLbHOoY4OMZDJfLDzBh7gNQh2c=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Update spdlog

Updates from version 1.15.3 to 1.16.0.

🤖 Generated with ekapkgs-update