### PR TITLE
pkgs: fix recurse

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,11 +9,11 @@ let
   inherit (pins) lib;
 
   filteredArgs = builtins.removeAttrs args [ "overlays" ];
+  pkgs = import ./stdenv/impure.nix (
+    {
+      inherit overlays;
+    }
+    // filteredArgs
+  );
 in
-
-import ./stdenv/impure.nix (
-  {
-    inherit overlays;
-  }
-  // filteredArgs
-)
+lib.recurseIntoAttrs pkgs


### PR DESCRIPTION
Not sure when this behavior was broken, but `nix-eval-jobs` was returning nothing. Seeing as how my previous `{ inherit grpc; }` expressions which I used previously also do not work, I'm starting to think that `nix-eval-jobs` now requires the top-level attrset to have `__recurseForDerivations = true;`