### PR TITLE
Haskell: init

### DIFF
--- a/pkgs-many/ghc/9.0.2-binary.nix
+++ b/pkgs-many/ghc/9.0.2-binary.nix
@@ -1,0 +1,535 @@
+{
+  mkVariantPassthru,
+  ...
+}@variantArgs:
+
+{
+  lib,
+  stdenv,
+  fetchurl,
+  perl,
+  ncurses5,
+  ncurses6,
+  gmp,
+  libiconv,
+  numactl,
+  libffi,
+  llvmPackages,
+  replaceVarsWith,
+  coreutils,
+  targetPackages,
+
+  # minimal = true; will remove files that aren't strictly necessary for
+  # regular builds and GHC bootstrapping.
+  # This is "useful" for staying within hydra's output limits for at least the
+  # aarch64-linux architecture.
+  minimal ? false,
+}@packageArgs:
+
+# Prebuilt only does native
+assert stdenv.targetPlatform == stdenv.hostPlatform;
+
+let
+  downloadsUrl = "https://downloads.haskell.org/ghc";
+
+  # Copy sha256 from https://downloads.haskell.org/~ghc/9.0.2/SHA256SUMS
+  version = "9.0.2";
+
+  # Information about available bindists that we use in the build.
+  #
+  # # Bindist library checking
+  #
+  # The field `archSpecificLibraries` also provides a way for us get notified
+  # early when the upstream bindist changes its dependencies (e.g. because a
+  # newer Debian version is used that uses a new `ncurses` version).
+  #
+  # Usage:
+  #
+  # * You can find the `fileToCheckFor` of libraries by running `readelf -d`
+  #   on the compiler binary (`exePathForLibraryCheck`).
+  # * To skip library checking for an architecture,
+  #   set `exePathForLibraryCheck = null`.
+  # * To skip file checking for a specific arch specific library,
+  #   set `fileToCheckFor = null`.
+  ghcBinDists = {
+    # Binary distributions for the default libc (e.g. glibc, or libSystem on Darwin)
+    # nixpkgs uses for the respective system.
+    defaultLibc = {
+      i686-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-i386-deb9-linux.tar.xz";
+          sha256 = "fdeb9f8928fbe994064778a8e1e85bb1a58a6cd3dd7b724fcc2a1dcfda6cad47";
+        };
+        exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          # The i686-linux bindist provided by GHC HQ is currently built on Debian 9,
+          # which link it against `libtinfo.so.5` (ncurses 5).
+          # Other bindists are linked `libtinfo.so.6` (ncurses 6).
+          {
+            nixPackage = ncurses5;
+            fileToCheckFor = "libtinfo.so.5";
+          }
+        ];
+      };
+      x86_64-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-deb10-linux.tar.xz";
+          sha256 = "5d0b9414b10cfb918453bcd01c5ea7a1824fe95948b08498d6780f20ba247afc";
+        };
+        exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libtinfo.so.6";
+          }
+          {
+            nixPackage = numactl;
+            fileToCheckFor = null;
+          }
+        ];
+      };
+      aarch64-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-deb10-linux.tar.xz";
+          sha256 = "cb016344c70a872738a24af60bd15d3b18749087b9905c1b3f1b1549dc01f46d";
+        };
+        exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libtinfo.so.6";
+          }
+          {
+            nixPackage = numactl;
+            fileToCheckFor = null;
+          }
+        ];
+      };
+      x86_64-darwin = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
+          sha256 = "e1fe990eb987f5c4b03e0396f9c228a10da71769c8a2bc8fadbc1d3b10a0f53a";
+        };
+        exePathForLibraryCheck = null; # we don't have a library check for darwin yet
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = libiconv;
+            fileToCheckFor = null;
+          }
+        ];
+        isHadrian = true;
+      };
+      aarch64-darwin = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-apple-darwin.tar.xz";
+          sha256 = "b1fcab17fe48326d2ff302d70c12bc4cf4d570dfbbce68ab57c719cfec882b05";
+        };
+        exePathForLibraryCheck = null; # we don't have a library check for darwin yet
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = libiconv;
+            fileToCheckFor = null;
+          }
+        ];
+        isHadrian = true;
+      };
+    };
+    # Binary distributions for the musl libc for the respective system.
+    musl = {
+      x86_64-linux = {
+        variantSuffix = "-musl";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3.12-linux-gmp.tar.xz";
+          sha256 = "5bb1e7192c2b9fcff68930dbdc65509d345138e9a43c5d447056a68decc05ec8";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libncursesw.so.6";
+          }
+        ];
+        isHadrian = true;
+      };
+    };
+  };
+
+  distSetName = if stdenv.hostPlatform.isMusl then "musl" else "defaultLibc";
+
+  binDistUsed =
+    ghcBinDists.${distSetName}.${stdenv.hostPlatform.system}
+      or (throw "cannot bootstrap GHC on this platform ('${stdenv.hostPlatform.system}' with libc '${distSetName}')");
+
+  gmpUsed =
+    (builtins.head (
+      builtins.filter (
+        drv: lib.hasPrefix "gmp" (drv.nixPackage.name or "")
+      ) binDistUsed.archSpecificLibraries
+    )).nixPackage;
+
+  useLLVM = !(import ./common-have-ncg.nix { inherit lib stdenv version; });
+
+  libPath = lib.makeLibraryPath (
+    # Add arch-specific libraries.
+    map ({ nixPackage, ... }: nixPackage) binDistUsed.archSpecificLibraries
+  );
+
+  libEnvVar = lib.optionalString stdenv.hostPlatform.isDarwin "DY" + "LD_LIBRARY_PATH";
+
+  runtimeDeps = [
+    targetPackages.stdenv.cc
+    targetPackages.stdenv.cc.bintools
+    coreutils # for cat
+  ]
+  ++ lib.optionals useLLVM [
+    # Allow the use of newer LLVM versions; see the script for details.
+    (replaceVarsWith {
+      name = "subopt";
+      src = ./subopt.bash;
+      dir = "bin";
+      isExecutable = true;
+      preBuild = ''
+        name=opt
+      '';
+      replacements = {
+        inherit (stdenv) shell;
+        opt = lib.getExe' llvmPackages.llvm "opt";
+      };
+    })
+    (lib.getBin llvmPackages.llvm)
+  ]
+  # On darwin, we need unwrapped bintools as well (for otool)
+  ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
+    targetPackages.stdenv.cc.bintools.bintools
+  ];
+
+in
+
+stdenv.mkDerivation {
+  inherit version;
+  pname = "ghc-binary${binDistUsed.variantSuffix}";
+
+  src = fetchurl binDistUsed.src;
+
+  nativeBuildInputs = [ perl ];
+
+  # Set LD_LIBRARY_PATH or equivalent so that the programs running as part
+  # of the bindist installer can find the libraries they expect.
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location.
+  ${libEnvVar} = libPath;
+
+  postUnpack =
+    # Verify our assumptions of which `libtinfo.so` (ncurses) version is used,
+    # so that we know when ghc bindists upgrade that and we need to update the
+    # version used in `libPath`.
+    lib.optionalString (binDistUsed.exePathForLibraryCheck != null)
+      # Note the `*` glob because some GHCs have a suffix when unpacked, e.g.
+      # the musl bindist has dir `ghc-VERSION-x86_64-unknown-linux/`.
+      # As a result, don't shell-quote this glob when splicing the string.
+      (
+        let
+          buildExeGlob = ''ghc-${version}*/"${binDistUsed.exePathForLibraryCheck}"'';
+        in
+        lib.concatStringsSep "\n" [
+          ''
+            shopt -u nullglob
+            echo "Checking that ghc binary exists in bindist at ${buildExeGlob}"
+            if ! test -e ${buildExeGlob}; then
+              echo >&2 "GHC binary ${binDistUsed.exePathForLibraryCheck} could not be found in the bindist build directory (at ${buildExeGlob}) for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+            fi
+          ''
+          (lib.concatMapStringsSep "\n" (
+            { fileToCheckFor, nixPackage }:
+            lib.optionalString (fileToCheckFor != null) ''
+              echo "Checking bindist for ${fileToCheckFor} to ensure that is still used"
+              if ! readelf -d ${buildExeGlob} | grep "${fileToCheckFor}"; then
+                echo >&2 "File ${fileToCheckFor} could not be found in ${binDistUsed.exePathForLibraryCheck} for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+              fi
+
+              echo "Checking that the nix package ${nixPackage} contains ${fileToCheckFor}"
+              if ! test -e "${lib.getLib nixPackage}/lib/${fileToCheckFor}"; then
+                echo >&2 "Nix package ${nixPackage} did not contain ${fileToCheckFor} for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+              fi
+            ''
+          ) binDistUsed.archSpecificLibraries)
+        ]
+      )
+    # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
+    # during linking
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export NIX_LDFLAGS+=" -no_dtrace_dof"
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find . -type f -executable); do
+        isScript $exe && continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
+      done
+    ''
+    +
+
+      # Some scripts used during the build need to have their shebangs patched
+      ''
+        patchShebangs ghc-${version}/utils/
+        patchShebangs ghc-${version}/configure
+        test -d ghc-${version}/inplace/bin && \
+          patchShebangs ghc-${version}/inplace/bin
+      ''
+    +
+      # We have to patch the GMP paths for the integer-gmp package.
+      ''
+        find . -name ghc-bignum.buildinfo \
+            -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${lib.getLib gmpUsed}/lib@" {} \;
+
+        # we need to modify the package db directly for hadrian bindists
+        find . -name 'ghc-bignum*.conf' \
+            -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib gmpUsed}/lib' -i {} \;
+      ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # we need to modify the package db directly for hadrian bindists
+      # (all darwin bindists are hadrian-based for 9.2.2)
+      find . -name 'base*.conf' \
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib libiconv}/lib' -i {} \;
+
+      # To link RTS in the end we also need libffi now
+      find . -name 'rts*.conf' \
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib libffi}/lib' \
+                    -e 's@/.*/Developer/.*/usr/include/ffi@${lib.getDev libffi}/include@' \
+                    -i {} \;
+    ''
+    +
+      # Some platforms do HAVE_NUMA so -lnuma requires it in library-dirs in rts/package.conf.in
+      # FFI_LIB_DIR is a good indication of places it must be needed.
+      lib.optionalString
+        (
+          lib.meta.availableOn stdenv.hostPlatform numactl
+          && builtins.any ({ nixPackage, ... }: nixPackage == numactl) binDistUsed.archSpecificLibraries
+        )
+        ''
+          find . -name package.conf.in \
+              -exec sed -i "s@FFI_LIB_DIR@FFI_LIB_DIR ${numactl.out}/lib@g" {} \;
+        ''
+    +
+      # Rename needed libraries and binaries, fix interpreter
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        find . -type f -executable -exec patchelf \
+            --interpreter ${stdenv.cc.bintools.dynamicLinker} {} \;
+      '';
+
+  # fix for `configure: error: Your linker is affected by binutils #16177`
+  preConfigure = lib.optionalString stdenv.targetPlatform.isAarch32 "LD=ld.gold";
+
+  configurePlatforms = [ ];
+  configureFlags = [
+    "--with-gmp-includes=${lib.getDev gmpUsed}/include"
+    # Note `--with-gmp-libraries` does nothing for GHC bindists:
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6124
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
+  # From: https://github.com/NixOS/nixpkgs/pull/43369/commits
+  ++ lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
+
+  # No building is necessary, but calling make without flags ironically
+  # calls install-strip ...
+  dontBuild = true;
+
+  # GHC tries to remove xattrs when installing to work around Gatekeeper
+  # (see https://gitlab.haskell.org/ghc/ghc/-/issues/17418). This step normally
+  # succeeds in nixpkgs because xattrs are not allowed in the store, but it
+  # can fail when a file has the `com.apple.provenance` xattr, and it can’t be
+  # modified (such as target of the symlink to `libiconv.dylib`).
+  # The `com.apple.provenance` xattr is a new feature of macOS as of macOS 13.
+  # See: https://eclecticlight.co/2023/03/13/ventura-has-changed-app-quarantine-with-a-new-xattr/
+  makeFlags = lib.optionals stdenv.buildPlatform.isDarwin [ "XATTR=/does-not-exist" ];
+
+  # Patch scripts to include runtime dependencies in $PATH.
+  postInstall = ''
+    for i in "$out/bin/"*; do
+      test ! -h "$i" || continue
+      isScript "$i" || continue
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
+    done
+  ''
+  # On Darwin, GHC doesn't install a bundled libffi.so, but instead uses the
+  # system one (see postUnpack). Due to a bug in Hadrian, the (bundled) libffi
+  # headers are installed anyways. This problem has been fixed in GHC 9.2:
+  # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8189. While the system
+  # header should shadow the GHC installed ones, remove them to be safe.
+  + lib.optionalString (stdenv.hostPlatform.isDarwin && binDistUsed.isHadrian or false) ''
+    echo Deleting redundant libffi headers:
+    find "$out" '(' -name ffi.h -or -name ffitarget.h ')' -print -delete
+  '';
+
+  # Apparently necessary for the ghc Alpine (musl) bindist:
+  # When we strip, and then run the
+  #     patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+  # below, running ghc (e.g. during `installCheckPhase)` gives some apparently
+  # corrupted rpath or whatever makes the loader work on nonsensical strings:
+  #     running install tests
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: : symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: ir6zf6c9f86pfx8sr30n2vjy-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/../lib/x86_64-linux-ghc-8.10.5/libHSexceptions-0.10.4-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: y/lib/ghc-8.10.5/bin/../lib/x86_64-linux-ghc-8.10.5/libHStemplate-haskell-2.16.0.0-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: 8.10.5/libHStemplate-haskell-2.16.0.0-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: �: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: �?: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: 64-linux-ghc-8.10.5/libHSexceptions-0.10.4-ghc8.10.5.so: symbol not found
+  # This is extremely bogus and should be investigated.
+  dontStrip = if stdenv.hostPlatform.isMusl then true else false; # `if` for explicitness
+
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  postFixup =
+    lib.optionalString (stdenv.hostPlatform.isLinux && !(binDistUsed.isStatic or false)) (
+      if stdenv.hostPlatform.isAarch64 then
+        # Keep rpath as small as possible on aarch64 for patchelf#244.  All Elfs
+        # are 2 directories deep from $out/lib, so pooling symlinks there makes
+        # a short rpath.
+        ''
+          (cd $out/lib; ln -s ${ncurses6.out}/lib/libtinfo.so.6)
+          (cd $out/lib; ln -s ${lib.getLib gmpUsed}/lib/libgmp.so.10)
+          (cd $out/lib; ln -s ${numactl.out}/lib/libnuma.so.1)
+          for p in $(find "$out/lib" -type f -name "*\.so*"); do
+            (cd $out/lib; ln -s $p)
+          done
+
+          for p in $(find "$out/lib" -type f -executable); do
+            if isELF "$p"; then
+              echo "Patchelfing $p"
+              patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../.." $p
+            fi
+          done
+        ''
+      else
+        ''
+          for p in $(find "$out" -type f -executable); do
+            if isELF "$p"; then
+              echo "Patchelfing $p"
+              patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+            fi
+          done
+        ''
+    )
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find "$out" -type f -executable); do
+        isScript $exe && continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
+      done
+
+      for file in $(find "$out" -name setup-config); do
+        substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+      done
+    ''
+    + lib.optionalString minimal ''
+      # Remove profiling files
+      find $out -type f -name '*.p_o' -delete
+      find $out -type f -name '*.p_hi' -delete
+      find $out -type f -name '*_p.a' -delete
+      # `-f` because e.g. musl bindist does not have this file.
+      rm -f $out/lib/ghc-*/bin/ghc-iserv-prof
+      # Hydra will redistribute this derivation, so we have to keep the docs for
+      # legal reasons (retaining the legal notices etc)
+      # As a last resort we could unpack the docs separately and symlink them in.
+      # They're in $out/share/{doc,man}.
+    ''
+    # Recache package db which needs to happen for Hadrian bindists
+    # where we modify the package db before installing
+    + ''
+      shopt -s nullglob
+      package_db=("$out"/lib/ghc-*/lib/package.conf.d "$out"/lib/ghc-*/package.conf.d)
+      "$out/bin/ghc-pkg" --package-db="$package_db" recache
+    '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      {-# LANGUAGE TemplateHaskell #-}
+      module Main where
+      main = putStrLn \$([|"yes"|])
+    EOF
+    env -i $out/bin/ghc --make main.hs || exit 1
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
+
+  passthru =
+    mkVariantPassthru variantArgs packageArgs
+    // {
+      targetPrefix = "";
+      enableShared = true;
+
+      inherit llvmPackages;
+
+      # Our Cabal compiler name
+      haskellCompilerName = "ghc-${version}";
+    }
+    # We duplicate binDistUsed here since we have a sensible default even if no bindist is available,
+    # this makes sure that getting the `meta` attribute doesn't throw even on unsupported platforms.
+    // lib.optionalAttrs (ghcBinDists.${distSetName}.${stdenv.hostPlatform.system}.isHadrian or false) {
+      # Normal GHC derivations expose the hadrian derivation used to build them
+      # here. In the case of bindists we just make sure that the attribute exists,
+      # as it is used for checking if a GHC derivation has been built with hadrian.
+      # The isHadrian mechanism will become obsolete with GHCs that use hadrian
+      # exclusively, i.e. 9.6 (and 9.4?).
+      hadrian = null;
+    };
+
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "Glasgow Haskell Compiler";
+    license = lib.licenses.bsd3;
+    # HACK: since we can't encode the libc / abi in platforms, we need
+    # to make the platform list dependent on the evaluation platform
+    # in order to avoid eval errors with musl which supports less
+    # platforms than the default libcs (i. e. glibc / libSystem).
+    # This is done for the benefit of Hydra, so `packagePlatforms`
+    # won't return any platforms that would cause an evaluation
+    # failure for `pkgsMusl.haskell.compiler.ghc922Binary`, as
+    # long as the evaluator runs on a platform that supports
+    # `pkgsMusl`.
+    platforms = builtins.attrNames ghcBinDists.${distSetName};
+    teams = [ lib.teams.haskell ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs-many/ghc/9.8.4-binary.nix
+++ b/pkgs-many/ghc/9.8.4-binary.nix
@@ -1,0 +1,486 @@
+{
+  mkVariantPassthru,
+  ...
+}@variantArgs:
+
+{
+  lib,
+  stdenv,
+  fetchurl,
+  perl,
+  ncurses5,
+  ncurses6,
+  gmp,
+  libiconv,
+  numactl,
+  libffi,
+  coreutils,
+  targetPackages,
+  llvmPackages,
+  replaceVarsWith,
+
+  # minimal = true; will remove files that aren't strictly necessary for
+  # regular builds and GHC bootstrapping.
+  # This is "useful" for staying within hydra's output limits for at least the
+  # aarch64-linux architecture.
+  minimal ? false,
+  ...
+}@packageArgs:
+
+# Prebuilt only does native
+assert stdenv.targetPlatform == stdenv.hostPlatform;
+
+let
+  downloadsUrl = "https://downloads.haskell.org/ghc";
+
+  # Copy sha256 from https://downloads.haskell.org/~ghc/9.8.4/SHA256SUMS
+  version = "9.8.4";
+
+  # Information about available bindists that we use in the build.
+  #
+  # # Bindist library checking
+  #
+  # The field `archSpecificLibraries` also provides a way for us get notified
+  # early when the upstream bindist changes its dependencies (e.g. because a
+  # newer Debian version is used that uses a new `ncurses` version).
+  #
+  # Usage:
+  #
+  # * You can find the `fileToCheckFor` of libraries by running `readelf -d`
+  #   on the compiler binary (`exePathForLibraryCheck`).
+  # * To skip library checking for an architecture,
+  #   set `exePathForLibraryCheck = null`.
+  # * To skip file checking for a specific arch specific library,
+  #   set `fileToCheckFor = null`.
+  ghcBinDists = {
+    # Binary distributions for the default libc (e.g. glibc, or libSystem on Darwin)
+    # nixpkgs uses for the respective system.
+    defaultLibc = {
+      i686-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-i386-deb10-linux.tar.xz";
+          sha256 = "e5efce16c654d5e702986258a87dd9531e1722b8051823c8ce1150ce3c5899ae";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libtinfo.so.6";
+          }
+        ];
+      };
+      x86_64-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-deb11-linux.tar.xz";
+          sha256 = "af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libtinfo.so.6";
+          }
+        ];
+      };
+      aarch64-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-deb11-linux.tar.xz";
+          sha256 = "310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libtinfo.so.6";
+          }
+        ];
+      };
+      x86_64-darwin = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
+          sha256 = "de7baacfb1513ab0e4ccf8911045cceee84bc8a4e39b89bd975ed3135e5f7d96";
+        };
+        exePathForLibraryCheck = null; # we don't have a library check for darwin yet
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = libiconv;
+            fileToCheckFor = null;
+          }
+        ];
+      };
+      aarch64-darwin = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-apple-darwin.tar.xz";
+          sha256 = "e2f12a922754fd28511512875bf6d9eb3e0cce7fc963a7266f6e1661aeabd7ed";
+        };
+        exePathForLibraryCheck = null; # we don't have a library check for darwin yet
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = libiconv;
+            fileToCheckFor = null;
+          }
+        ];
+      };
+    };
+    # Binary distributions for the musl libc for the respective system.
+    musl = {
+      aarch64-linux = {
+        variantSuffix = "-musl";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-alpine3_18-linux.tar.xz";
+          sha256 = "b5c86a0cda0bd62d5eeeb52b1937c3bd00c70cd67dd74226ce787d5c429a4e62";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libncursesw.so.6";
+          }
+        ];
+      };
+      x86_64-linux = {
+        variantSuffix = "-musl";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3_12-linux.tar.xz";
+          sha256 = "e34bb16e8387509adc96a3d98b4a444bab425d12864c38a3629f2860b4bec2e7";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libncursesw.so.6";
+          }
+        ];
+      };
+    };
+  };
+
+  distSetName = if stdenv.hostPlatform.isMusl then "musl" else "defaultLibc";
+
+  binDistUsed =
+    ghcBinDists.${distSetName}.${stdenv.hostPlatform.system}
+      or (throw "cannot bootstrap GHC on this platform ('${stdenv.hostPlatform.system}' with libc '${distSetName}')");
+
+  gmpUsed =
+    (builtins.head (
+      builtins.filter (
+        drv: lib.hasPrefix "gmp" (drv.nixPackage.name or "")
+      ) binDistUsed.archSpecificLibraries
+    )).nixPackage;
+
+  libPath = lib.makeLibraryPath (
+    # Add arch-specific libraries.
+    map ({ nixPackage, ... }: nixPackage) binDistUsed.archSpecificLibraries
+  );
+
+  libEnvVar = lib.optionalString stdenv.hostPlatform.isDarwin "DY" + "LD_LIBRARY_PATH";
+
+  runtimeDeps = [
+    targetPackages.stdenv.cc
+    targetPackages.stdenv.cc.bintools
+    coreutils # for cat
+  ]
+  # On darwin, we need unwrapped bintools as well (for otool)
+  ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
+    targetPackages.stdenv.cc.bintools.bintools
+  ];
+
+in
+
+stdenv.mkDerivation {
+  inherit version;
+  pname = "ghc-binary${binDistUsed.variantSuffix}";
+
+  src = fetchurl binDistUsed.src;
+
+  nativeBuildInputs = [ perl ];
+
+  # Set LD_LIBRARY_PATH or equivalent so that the programs running as part
+  # of the bindist installer can find the libraries they expect.
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location.
+  ${libEnvVar} = libPath;
+
+  postUnpack =
+    # Verify our assumptions of which `libtinfo.so` (ncurses) version is used,
+    # so that we know when ghc bindists upgrade that and we need to update the
+    # version used in `libPath`.
+    lib.optionalString (binDistUsed.exePathForLibraryCheck != null)
+      # Note the `*` glob because some GHCs have a suffix when unpacked, e.g.
+      # the musl bindist has dir `ghc-VERSION-x86_64-unknown-linux/`.
+      # As a result, don't shell-quote this glob when splicing the string.
+      (
+        let
+          buildExeGlob = ''ghc-${version}*/"${binDistUsed.exePathForLibraryCheck}"'';
+        in
+        lib.concatStringsSep "\n" [
+          ''
+            shopt -u nullglob
+            echo "Checking that ghc binary exists in bindist at ${buildExeGlob}"
+            if ! test -e ${buildExeGlob}; then
+              echo >&2 "GHC binary ${binDistUsed.exePathForLibraryCheck} could not be found in the bindist build directory (at ${buildExeGlob}) for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+            fi
+          ''
+          (lib.concatMapStringsSep "\n" (
+            { fileToCheckFor, nixPackage }:
+            lib.optionalString (fileToCheckFor != null) ''
+              echo "Checking bindist for ${fileToCheckFor} to ensure that is still used"
+              if ! readelf -d ${buildExeGlob} | grep "${fileToCheckFor}"; then
+                echo >&2 "File ${fileToCheckFor} could not be found in ${binDistUsed.exePathForLibraryCheck} for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+              fi
+
+              echo "Checking that the nix package ${nixPackage} contains ${fileToCheckFor}"
+              if ! test -e "${lib.getLib nixPackage}/lib/${fileToCheckFor}"; then
+                echo >&2 "Nix package ${nixPackage} did not contain ${fileToCheckFor} for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+              fi
+            ''
+          ) binDistUsed.archSpecificLibraries)
+        ]
+      )
+    # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
+    # during linking
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export NIX_LDFLAGS+=" -no_dtrace_dof"
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find . -type f -executable); do
+        isMachO $exe || continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
+      done
+    ''
+
+    # We have to patch the GMP paths for the ghc-bignum package, for hadrian by
+    # modifying the package-db directly
+    + ''
+      find . -name 'ghc-bignum*.conf' \
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib gmpUsed}/lib' -i {} \;
+    ''
+    # Similar for iconv and libffi on darwin
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      find . -name 'base*.conf' \
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib libiconv}/lib' -i {} \;
+
+      # To link RTS in the end we also need libffi now
+      find . -name 'rts*.conf' \
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib libffi}/lib' \
+                    -e 's@/Library/Developer/.*/usr/include/ffi@${lib.getDev libffi}/include@' \
+                    -i {} \;
+    ''
+    +
+      # Some platforms do HAVE_NUMA so -lnuma requires it in library-dirs in rts/package.conf.in
+      # FFI_LIB_DIR is a good indication of places it must be needed.
+      lib.optionalString
+        (
+          lib.meta.availableOn stdenv.hostPlatform numactl
+          && builtins.any ({ nixPackage, ... }: nixPackage == numactl) binDistUsed.archSpecificLibraries
+        )
+        ''
+          find . -name package.conf.in \
+              -exec sed -i "s@FFI_LIB_DIR@FFI_LIB_DIR ${numactl.out}/lib@g" {} \;
+        ''
+    +
+      # Rename needed libraries and binaries, fix interpreter
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        find . -type f -executable -exec patchelf \
+            --interpreter ${stdenv.cc.bintools.dynamicLinker} {} \;
+      '';
+
+  # fix for `configure: error: Your linker is affected by binutils #16177`
+  preConfigure = lib.optionalString stdenv.targetPlatform.isAarch32 "LD=ld.gold";
+
+  # GHC has a patched config.sub and bindists' platforms should always work
+  dontUpdateAutotoolsGnuConfigScripts = true;
+
+  configurePlatforms = [ ];
+  configureFlags =
+    lib.optional stdenv.hostPlatform.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
+    # From: https://github.com/NixOS/nixpkgs/pull/43369/commits
+    ++ lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
+
+  # No building is necessary, but calling make without flags ironically
+  # calls install-strip ...
+  dontBuild = true;
+
+  # Patch scripts to include runtime dependencies in $PATH.
+  postInstall = ''
+    for i in "$out/bin/"*; do
+      test ! -h "$i" || continue
+      isScript "$i" || continue
+      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
+    done
+  ''
+  + lib.optionalString stdenv.targetPlatform.isDarwin ''
+    # Work around building with binary GHC on Darwin due to GHC’s use of `ar -L` when it
+    # detects `llvm-ar` even though the resulting archives are not supported by ld64.
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/23188
+    # https://github.com/haskell/cabal/issues/8882
+    sed -i -e 's/,("ar supports -L", "YES")/,("ar supports -L", "NO")/' "$out/lib/ghc-${version}/lib/settings"
+  '';
+
+  # Apparently necessary for the ghc Alpine (musl) bindist:
+  # When we strip, and then run the
+  #     patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+  # below, running ghc (e.g. during `installCheckPhase)` gives some apparently
+  # corrupted rpath or whatever makes the loader work on nonsensical strings:
+  #     running install tests
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: : symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: ir6zf6c9f86pfx8sr30n2vjy-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/../lib/x86_64-linux-ghc-8.10.5/libHSexceptions-0.10.4-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: y/lib/ghc-8.10.5/bin/../lib/x86_64-linux-ghc-8.10.5/libHStemplate-haskell-2.16.0.0-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: 8.10.5/libHStemplate-haskell-2.16.0.0-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: �: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: �?: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: 64-linux-ghc-8.10.5/libHSexceptions-0.10.4-ghc8.10.5.so: symbol not found
+  # This is extremely bogus and should be investigated.
+  dontStrip = if stdenv.hostPlatform.isMusl then true else false; # `if` for explicitness
+
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  postFixup =
+    lib.optionalString (stdenv.hostPlatform.isLinux && !(binDistUsed.isStatic or false)) (
+      if stdenv.hostPlatform.isAarch64 then
+        # Keep rpath as small as possible on aarch64 for patchelf#244.  All Elfs
+        # are 2 directories deep from $out/lib, so pooling symlinks there makes
+        # a short rpath.
+        ''
+          (cd $out/lib; ln -s ${lib.getLib gmpUsed}/lib/libgmp.so.10)
+        ''
+        + (
+          if stdenv.hostPlatform.isMusl then
+            ''
+              (cd $out/lib; ln -s ${ncurses6.out}/lib/libncursesw.so.6)
+            ''
+          else
+            ''
+              (cd $out/lib; ln -s ${ncurses6.out}/lib/libtinfo.so.6)
+            ''
+        )
+        + ''
+          for p in $(find "$out/lib" -type f -name "*\.so*"); do
+            (cd $out/lib; ln -s $p)
+          done
+
+          for p in $(find "$out/lib" -type f -executable); do
+            if isELF "$p"; then
+              echo "Patchelfing $p"
+              patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../.." $p
+            fi
+          done
+        ''
+      else
+        ''
+          for p in $(find "$out" -type f -executable); do
+            if isELF "$p"; then
+              echo "Patchelfing $p"
+              patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+            fi
+          done
+        ''
+    )
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find "$out" -type f -executable); do
+        isMachO $exe || continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib $exe
+      done
+
+      for file in $(find "$out" -name setup-config); do
+        substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+      done
+    ''
+    # Recache package db which needs to happen for Hadrian bindists
+    # where we modify the package db before installing
+    + ''
+      package_db=("$out"/lib/ghc-*/lib/package.conf.d)
+      "$out/bin/ghc-pkg" --package-db="$package_db" recache
+    '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      {-# LANGUAGE TemplateHaskell #-}
+      module Main where
+      main = putStrLn \$([|"yes"|])
+    EOF
+    env -i $out/bin/ghc --make main.hs || exit 1
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
+
+  passthru = mkVariantPassthru variantArgs packageArgs // {
+    targetPrefix = "";
+    enableShared = true;
+
+    llvmPackages = null;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc-${version}";
+
+    # Normal GHC derivations expose the hadrian derivation used to build them
+    # here. In the case of bindists we just make sure that the attribute exists,
+    # as it is used for checking if a GHC derivation has been built with hadrian.
+    hadrian = null;
+  };
+
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "Glasgow Haskell Compiler";
+    license = lib.licenses.bsd3;
+    # HACK: since we can't encode the libc / abi in platforms, we need
+    # to make the platform list dependent on the evaluation platform
+    # in order to avoid eval errors with musl which supports less
+    # platforms than the default libcs (i. e. glibc / libSystem).
+    # This is done for the benefit of Hydra, so `packagePlatforms`
+    # won't return any platforms that would cause an evaluation
+    # failure for `pkgsMusl.haskell.compiler.ghc922Binary`, as
+    # long as the evaluator runs on a platform that supports
+    # `pkgsMusl`.
+    platforms = builtins.attrNames ghcBinDists.${distSetName};
+    broken = !(import ./common-have-ncg.nix { inherit lib stdenv version; });
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs-many/ghc/common-have-ncg.nix
+++ b/pkgs-many/ghc/common-have-ncg.nix
@@ -1,0 +1,14 @@
+# Determines whether the Native Code Generation (NCG) backend of the given
+# GHC `version` is supported for compiling to `stdenv.targetPlatform`.
+{
+  version,
+  stdenv,
+  lib,
+}:
+
+stdenv.targetPlatform.isx86
+|| stdenv.targetPlatform.isPower
+|| (lib.versionOlder version "9.4" && stdenv.targetPlatform.isSparc)
+|| (lib.versionAtLeast version "9.2" && stdenv.targetPlatform.isAarch64)
+|| (lib.versionAtLeast version "9.6" && stdenv.targetPlatform.isGhcjs)
+|| (lib.versionAtLeast version "9.12" && stdenv.targetPlatform.isRiscV64)

--- a/pkgs-many/ghc/default.nix
+++ b/pkgs-many/ghc/default.nix
@@ -1,0 +1,10 @@
+{ mkManyVariants }:
+
+mkManyVariants {
+  variants = ./variants.nix;
+  aliases = { };
+  # Use binary GHC for now until we have Haskell package infrastructure
+  # to build hadrian and its dependencies
+  defaultSelector = (p: p.v9_8_4_binary);
+  genericBuilder = ./generic.nix;
+}

--- a/pkgs-many/ghc/generic.nix
+++ b/pkgs-many/ghc/generic.nix
@@ -1,0 +1,25 @@
+{
+  version,
+  sha256 ? null,
+  rev ? null,
+  isBinary ? false,
+  useMake ? false,
+  packageAtLeast,
+  packageOlder,
+  mkVariantPassthru,
+  ...
+}@variantArgs:
+
+# For binary versions, we import the complete binary package file directly
+if isBinary then
+  import ./${version}.nix variantArgs
+
+# For GHC 9.4.x and older, use the Make-based build system
+else if useMake then
+  import ./common-make-native-bignum.nix {
+    inherit version sha256;
+  }
+
+# For modern GHC (9.6+), use the Hadrian build system
+else
+  import ./common-hadrian.nix variantArgs

--- a/pkgs-many/ghc/subopt.bash
+++ b/pkgs-many/ghc/subopt.bash
@@ -1,0 +1,81 @@
+#!@shell@
+
+# This script wraps the LLVM `opt(1)` executable and maps the options
+# passed by old versions of GHC to the equivalents passed by newer
+# versions that support recent versions of LLVM.
+#
+# It achieves the same effect as the following GHC change externally:
+# <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8999>.
+#
+# This is used solely for bootstrapping newer GHCs from the GHC 9.0.2
+# binary on AArch64, as that is the only architecture supported by that
+# binary distribution that requires LLVM, and our later binary packages
+# all use the native code generator for all supported platforms.
+#
+# No attempt is made to support custom LLVM optimization flags, or the
+# undocumented flag to disable TBAA, or avoid
+# <https://gitlab.haskell.org/ghc/ghc/-/issues/23870> (krank:ignore-line),
+# as these are not required to bootstrap GHC and at worst will produce an
+# error message.
+#
+# It is called `subopt` to reflect the fact that it uses `opt(1)` as a
+# subprocess, and the fact that the GHC build system situation
+# requiring this hack is suboptimal.
+
+set -e
+
+expect() {
+  if [[ $1 != $2 ]]; then
+    printf >&2 'subopt: got %q; expected %q\n' "$1" "$2"
+    return 2
+  fi
+}
+
+if [[ $NIX_DEBUG -ge 1 ]]; then
+  printf >&2 'subopt: before:'
+  printf >&2 ' %q' "$@"
+  printf >&2 '\n'
+fi
+
+args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -enable-new-pm=0)
+      shift 1
+      ;;
+    -mem2reg)
+      expect "$2" -globalopt
+      expect "$3" -lower-expect
+      expect "$4" -enable-tbaa
+      expect "$5" -tbaa
+      args+=('-passes=function(require<tbaa>),function(mem2reg),globalopt,function(lower-expect)')
+      shift 5
+      ;;
+    -O1)
+      expect "$2" -globalopt
+      expect "$3" -enable-tbaa
+      expect "$4" -tbaa
+      args+=('-passes=default<O1>')
+      shift 4
+      ;;
+    -O2)
+      expect "$2" -enable-tbaa
+      expect "$3" -tbaa
+      args+=('-passes=default<O2>')
+      shift 3
+      ;;
+    *)
+      args+=("$1")
+      shift 1
+      ;;
+  esac
+done
+
+if [[ $NIX_DEBUG -ge 1 ]]; then
+  printf >&2 'subopt: after:'
+  printf >&2 ' %q' "${args[@]}"
+  printf >&2 '\n'
+fi
+
+exec @opt@ "${args[@]}"

--- a/pkgs-many/ghc/variants.nix
+++ b/pkgs-many/ghc/variants.nix
@@ -1,0 +1,12 @@
+{
+  # Binary bootstrap compilers only
+  # Source-based GHC versions removed to avoid needing Haskell package set curation
+  v9_0_2_binary = {
+    version = "9.0.2-binary";
+    isBinary = true;
+  };
+  v9_8_4_binary = {
+    version = "9.8.4-binary";
+    isBinary = true;
+  };
+}

--- a/pkgs/numactl/default.nix
+++ b/pkgs/numactl/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  autoreconfHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "numactl";
+  version = "2.0.18";
+
+  src = fetchFromGitHub {
+    owner = "numactl";
+    repo = "numactl";
+    rev = "v${version}";
+    hash = "sha256-ry29RUNa0Hv5gIhy2RTVT94mHhgfdIwb5aqjBycxxj0=";
+  };
+
+  patches = [
+    # Fix for memory corruption in set_nodemask_size
+    (fetchpatch {
+      url = "https://github.com/numactl/numactl/commit/f9deba0c8404529772468d6dd01389f7dbfa5ba9.patch";
+      hash = "sha256-TmWfD99YaSIHA5PSsWHE91GSsdsVgVU+qIow7LOwOGw=";
+    })
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  postPatch = ''
+    patchShebangs test
+  '';
+
+  # You probably shouldn't ever run these! They will reconfigure Linux
+  # NUMA settings, which on my build machine makes the rest of package
+  # building ~5% slower until reboot. Ugh!
+  doCheck = false; # never ever!
+
+  meta = {
+    description = "Library and tools for non-uniform memory access (NUMA) machines";
+    homepage = "https://github.com/numactl/numactl";
+    license = with lib.licenses; [
+      gpl2Only
+      lgpl21
+    ]; # libnuma is lgpl21
+    platforms = lib.platforms.linux;
+  };
+}

--- a/top-level.nix
+++ b/top-level.nix
@@ -190,6 +190,7 @@ with final;
   wireshark = null;
   wlroots_0_17 = null;
   wlroots_0_18 = null;
+  xattr = null;
   xwayland = null;
   yallback = null;
   yamllint = null;
@@ -940,6 +941,31 @@ with final;
     langJit = true;
     enableLTO = false;
   };
+
+  # Utility to extract just the source from a derivation
+  srcOnly =
+    args:
+    (callPackage (
+      {
+        runCommand,
+        lib,
+        stdenvNoCC,
+      }:
+      drv:
+      runCommand "${drv.name}-src"
+        {
+          outputs = [ "out" ];
+          preferLocalBuild = true;
+        }
+        ''
+          mkdir -p $out
+          ${lib.concatMapStringsSep "\n" (output: ''
+            if [ -d "${drv.${output}}" ]; then
+              cp -r "${drv.${output}}"/* $out/
+            fi
+          '') (drv.outputs or [ "out" ])}
+        ''
+    ) { } args);
 
   wrapCCWith =
     {


### PR DESCRIPTION
Add GHC 9.0.2 and 9.8.4 binaries. These are used to bootstrap the "from source" GHC's. However, truly bootstrapping also brings in the haskell package set, which should exist in a downstream repo.