### PR TITLE
Create consistent way to defer unittests to passthru

### DIFF
--- a/pkgs/libseccomp/default.nix
+++ b/pkgs/libseccomp/default.nix
@@ -9,9 +9,10 @@
   gperf,
   nix-update-script,
   python3Packages,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "libseccomp";
   version = "2.6.0";
 
@@ -58,8 +59,7 @@ stdenv.mkDerivation rec {
     which
   ];
 
-  # Test suite is quite long
-  # TODO(corepkgs): move unittests to passthru
+  # Test suite is quite long, run as passthru
   doCheck = false;
 
   # Hack to ensure that patchelf --shrink-rpath get rids of a $TMPDIR reference.
@@ -76,6 +76,7 @@ stdenv.mkDerivation rec {
     updateScript = nix-update-script { };
     tests = {
       inherit (python3Packages) seccomp;
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
   };
 
@@ -96,4 +97,4 @@ stdenv.mkDerivation rec {
     ];
     maintainers = [ ];
   };
-}
+})

--- a/top-level.nix
+++ b/top-level.nix
@@ -1065,6 +1065,7 @@ with final;
   replaceVars = callPackage ./build-support/replace-vars/replace-vars.nix { };
   replaceDirectDependencies = callPackage ./build-support/replace-direct-dependencies.nix { };
 
+  runUnitTests = pkg: pkg.overrideAttrs { doCheck = true; };
   runtimeShell = "${runtimeShellPackage}${runtimeShellPackage.shellPath}";
   runtimeShellPackage = bashNonInteractive;
   bash = callPackage ./pkgs/bash/5.nix { };


### PR DESCRIPTION
Would like an established paradigm for moving unittests to passthru. `finalAttrs.finalPackage` + `overrideAttrs` seems like a decent localized (within the expression) way to do this.