### PR TITLE
treewide: adopt testers.pkg-config.testInstall

### DIFF
--- a/pkgs-many/ncurses/generic.nix
+++ b/pkgs-many/ncurses/generic.nix
@@ -293,6 +293,9 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     ldflags = "-lncurses";
     inherit unicodeSupport abiVersion;
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+    };
   };
 })

--- a/pkgs-many/ncurses/variants.nix
+++ b/pkgs-many/ncurses/variants.nix
@@ -5,9 +5,11 @@
 
   v5 = {
     abiVersion = "5";
+    version = "6.5";
   };
 
   v6 = {
     abiVersion = "6";
+    version = "6.5";
   };
 }

--- a/pkgs-many/openssl/generic.nix
+++ b/pkgs-many/openssl/generic.nix
@@ -397,7 +397,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+    };
   };
 
   meta = {

--- a/pkgs/alsa-lib/default.nix
+++ b/pkgs/alsa-lib/default.nix
@@ -38,7 +38,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+    };
     updateScript = directoryListingUpdater {
       url = "https://www.alsa-project.org/files/pub/lib/";
     };

--- a/pkgs/audit/default.nix
+++ b/pkgs/audit/default.nix
@@ -154,6 +154,7 @@ stdenv.mkDerivation (finalAttrs: {
       musl = pkgsMusl.audit or null;
       static = pkgsStatic.audit or null;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
       audit = nixosTests.audit;
       # Broken on a hardened kernel
       package = finalAttrs.finalPackage.overrideAttrs (previousAttrs: {

--- a/pkgs/brotli/default.nix
+++ b/pkgs/brotli/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests = {
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
     python = python3Packages.brotli;
   };
 

--- a/pkgs/curl/default.nix
+++ b/pkgs/curl/default.nix
@@ -271,6 +271,7 @@ stdenv.mkDerivation (finalAttrs: {
         # nginx-http3 = useThisCurl nixosTests.nginx-http3;
         nginx-http3 = nixosTests.nginx-http3;
         pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+        pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
         static = pkgsStatic.curl;
       };
     };

--- a/pkgs/file/default.nix
+++ b/pkgs/file/default.nix
@@ -60,7 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = lib.optional stdenv.hostPlatform.isWindows "FILE_COMPILE=file";
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+  };
 
   meta = {
     homepage = "https://darwinsys.com/file";

--- a/pkgs/icu/make-icu.nix
+++ b/pkgs/icu/make-icu.nix
@@ -172,7 +172,10 @@ let
       finalAttrs:
       attrs
       // {
-        passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+        passthru.tests = {
+          pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+          pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+        };
         passthru.buildRootOnly = mkWithAttrs buildRootOnlyAttrs;
       }
     );

--- a/pkgs/libcap_ng/default.nix
+++ b/pkgs/libcap_ng/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = nix-update-script { };
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
     };
   };
 

--- a/pkgs/libjpeg_turbo/default.nix
+++ b/pkgs/libjpeg_turbo/default.nix
@@ -106,6 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
         ;
       inherit (python3.pkgs) pillow imread pyturbojpeg;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
     };
   };
 

--- a/pkgs/libpng/default.nix
+++ b/pkgs/libpng/default.nix
@@ -47,7 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     inherit zlib;
 
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+    };
   };
 
   meta = {

--- a/pkgs/libpthread-stubs/default.nix
+++ b/pkgs/libpthread-stubs/default.nix
@@ -26,7 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
 
       update-source-version ${finalAttrs.pname} "$version"
     '';
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+    };
   };
 
   meta = {

--- a/pkgs/libsodium/default.nix
+++ b/pkgs/libsodium/default.nix
@@ -37,7 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+  };
 
   meta = {
     description = "Modern and easy-to-use crypto library";

--- a/pkgs/libudev-zero/default.nix
+++ b/pkgs/libudev-zero/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests = {
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
   };
 
   meta = {

--- a/pkgs/libuv/default.nix
+++ b/pkgs/libuv/default.nix
@@ -194,6 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
     python-uvloop = python3.pkgs.uvloop;
     static = pkgsStatic.libuv;
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
   };
 
   meta = {

--- a/pkgs/rapidcheck/default.nix
+++ b/pkgs/rapidcheck/default.nix
@@ -35,7 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = unstableGitUpdater { };
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+    };
   };
 
   meta = {

--- a/pkgs/xcb-proto/default.nix
+++ b/pkgs/xcb-proto/default.nix
@@ -24,7 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+    };
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell
       #!nix-shell -i bash -p common-updater-scripts

--- a/pkgs/zeromq/default.nix
+++ b/pkgs/zeromq/default.nix
@@ -110,6 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     pyzmq = python3.pkgs.pyzmq;
     ffmpeg = ffmpeg.override { withZmq = true; };
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
   };
 
   meta = {

--- a/pkgs/zlib/default.nix
+++ b/pkgs/zlib/default.nix
@@ -150,6 +150,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests = {
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
     # uses `zlib` derivation:
     inherit minizip;
   };

--- a/top-level.nix
+++ b/top-level.nix
@@ -1384,11 +1384,13 @@ with final;
   ncurses =
     if stdenv.hostPlatform.useiOSPrebuilt then
       null
-    else
+    else if stdenv.hostPlatform.isDarwin then
       prev.ncurses.override {
         # ncurses is included in the SDK. Avoid an infinite recursion by using a bootstrap stdenv.
-        stdenv = if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
-      };
+        stdenv = darwin.bootstrapStdenv;
+      }
+    else
+      prev.ncurses;
 
   pkgconf = callPackage ./build-support/pkg-config-wrapper {
     pkg-config = pkgconf-unwrapped;


### PR DESCRIPTION
Make use of the pkg-config installer test for packages already making use of `testMetaPkgConfig`