### PR TITLE
flex: polish build

### DIFF
--- a/pkgs-many/flex/default.nix
+++ b/pkgs-many/flex/default.nix
@@ -3,7 +3,7 @@
 mkManyVariants {
   variants = ./variants.nix;
   aliases = { };
-  defaultSelector = (p: p.v2_6_4);
+  defaultSelector = (p: p.v2_6);
   genericBuilder = ./generic.nix;
   inherit callPackage;
 }

--- a/pkgs-many/flex/generic.nix
+++ b/pkgs-many/flex/generic.nix
@@ -1,13 +1,6 @@
 {
   version,
-  src-url,
   src-hash,
-  needsFlexBootstrap ? false,
-  needsTexinfo ? false,
-  doCheck ? true,
-  glibcPatchUrl ? null,
-  glibcPatchHash ? null,
-  metaHomepage,
   packageOlder,
   packageAtLeast,
   ...
@@ -29,23 +22,30 @@
 # Avoid 'fetchpatch' to allow 'flex' to be used as a possible 'gcc'
 # dependency during bootstrap. Useful when gcc is built from snapshot
 # or from a git tree (flex lexers are not pre-generated there).
+let
+  is2_5 = packageOlder "2.6";
+  url =
+    if is2_5 then
+      "https://github.com/westes/flex/releases/download/flex-${version}/flex-${version}.tar.gz"
+    else
+      "https://github.com/westes/flex/releases/download/v${version}/flex-${version}.tar.gz";
 
+  needsTexinfo = is2_5;
+in
 stdenv.mkDerivation rec {
   pname = "flex";
   inherit version;
 
+  # Use the published sources associated with a tag to avoid the need to run flex as part of build
   src = fetchurl {
-    url = src-url;
+    inherit url;
     hash = src-hash;
   };
 
-  # v2.6.4 needs glibc-2.26 patch (will be part of 2.6.5)
-  # https://github.com/westes/flex/commit/24fd0551333e
-  patches = lib.optionals (glibcPatchUrl != null) [
+  patches = lib.optionals (packageAtLeast "2.6") [
     (fetchurl {
-      name = "glibc-2.26.patch";
-      url = glibcPatchUrl;
-      hash = glibcPatchHash;
+      url = "https://raw.githubusercontent.com/lede-project/source/0fb14a2b1ab2f82ce63f4437b062229d73d90516/tools/flex/patches/200-build-AC_USE_SYSTEM_EXTENSIONS-in-configure.ac.patch";
+      hash = "sha256-eSDA0hIIfQbXx0DP1dTQU2uIqBxIXjbB6O+E134g91Y=";
     })
   ];
 
@@ -60,16 +60,13 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = lib.optionals (packageAtLeast "2.6") [ buildPackages.stdenv.cc ];
 
-  nativeBuildInputs =
-    # v2.5.35 needs flex to build itself (bootstrap)
-    lib.optionals needsFlexBootstrap [ flex ]
-    ++ [
-      bison
-      help2man
-      autoreconfHook
-    ]
-    # v2.5.35 needs texinfo
-    ++ lib.optionals needsTexinfo [ texinfo ];
+  nativeBuildInputs = [
+    bison
+    help2man
+    autoreconfHook
+  ]
+  # v2.5.35 needs texinfo
+  ++ lib.optionals needsTexinfo [ texinfo ];
 
   buildInputs = lib.optionals (packageAtLeast "2.6") [ bison ];
 
@@ -86,24 +83,17 @@ stdenv.mkDerivation rec {
 
   dontDisableStatic = stdenv.buildPlatform != stdenv.hostPlatform;
 
-  inherit doCheck;
+  doCheck = false;
 
   postInstall = ''
     ln -s $out/bin/flex $out/bin/lex
   '';
 
   meta = {
-    homepage = metaHomepage;
+    homepage = "https://github.com/westes/flex";
     description = "Fast lexical analyser generator";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
-  }
-  # v2.5.35 has a branch attribute in meta
-  // lib.optionalAttrs (packageOlder "2.6") {
-    branch = version;
-  }
-  # v2.6+ has mainProgram in meta
-  // lib.optionalAttrs (packageAtLeast "2.6") {
     mainProgram = "flex";
   };
 }

--- a/pkgs-many/flex/variants.nix
+++ b/pkgs-many/flex/variants.nix
@@ -1,29 +1,16 @@
 {
-  v2_5_35 = rec {
-    version = "2.5.35";
-    src-hash = "sha256-0wh06nix8bd4w1aq4k2fbbkdq5i30a9lxz3xczf3ff28yy0kfwzm=";
-    # Uses GitHub archive format instead of releases
-    src-url = "https://github.com/westes/flex/archive/flex-${
-      builtins.replaceStrings [ "." ] [ "-" ] version
-    }.tar.gz";
-    # v2.5.35 needs flex to build itself (bootstrap dependency)
-    needsFlexBootstrap = true;
-    # v2.5.35 needs texinfo in addition to help2man
+  v2_5 = rec {
+    version = "2.5.39";
+    src-hash = "sha256-cd0bWBWMk1AnEEyDDAGeSMcyUHCK9d70XqJWx4kxiUg=";
     needsTexinfo = true;
-    # Tests fail for this version
-    doCheck = false;
-    # Older meta homepage
-    metaHomepage = "https://flex.sourceforge.net/";
   };
 
-  v2_6_4 = rec {
+  v2_6 = rec {
     version = "2.6.4";
     src-hash = "sha256-6HquAyvwfCb4WsDtMlCZjDdiHZX4vXSLMfFbM8Re6ZU=";
-    src-url = "https://github.com/westes/flex/releases/download/v${version}/flex-${version}.tar.gz";
     # This version needs the glibc-2.26 patch (will be part of 2.6.5)
     # Using fetchurl directly to avoid 'fetchpatch' dependency for bootstrap
     glibcPatchUrl = "https://raw.githubusercontent.com/lede-project/source/0fb14a2b1ab2f82ce63f4437b062229d73d90516/tools/flex/patches/200-build-AC_USE_SYSTEM_EXTENSIONS-in-configure.ac.patch";
     glibcPatchHash = "sha256-eSDA0hIIfQbXx0DP1dTQU2uIqBxIXjbB6O+E134g91Y=";
-    metaHomepage = "https://github.com/westes/flex";
   };
 }

--- a/stdenv/aliases.nix
+++ b/stdenv/aliases.nix
@@ -37,6 +37,7 @@ mapAliases {
   db6 = db.v6_0;
   db60 = db.v6_0;
   db62 = db.v6_2;
+  flex_2_5_39 = flex.v2_5_39;
   gmp6 = gmp.variants.v6_3;
   gmpxx = gmp.variants.cxx;
   go_1_24 = go.v1_24;

--- a/top-level.nix
+++ b/top-level.nix
@@ -1031,8 +1031,6 @@ with final;
   };
   bashInteractiveFHS = bashFHS;
 
-  flex_2_5_35 = flex.v2_5_35;
-
   # Python interpreters. All standard library modules are included except for tkinter, which is
   # available as `pythonPackages.tkinter` and can be used as any other Python package.
   python = python3;


### PR DESCRIPTION
Clean this up. `flex` 2.5 still fails to build for compiler warnings, but I don't care to fix this right now