### PR TITLE
pkgsX: Avoid recursing

### DIFF
--- a/stdenv/variants.nix
+++ b/stdenv/variants.nix
@@ -22,7 +22,8 @@ let
       }
     );
 in
-self: super: {
+self: super:
+builtins.mapAttrs (_: v: if builtins.isAttrs v then lib.dontRecurseIntoAttrs v else v) {
   pkgsLLVM = nixpkgsFun {
     overlays = [
       (self': super': {


### PR DESCRIPTION
may just be the regression in nix-eval-jobs, but `pkgsCuda` and others will be recursed if we don't do this.