### PR TITLE
Default doCheck to false

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Pre-commit hook: format staged files with `nix fmt`.
+#
+# Enable in this repo by running:
+#   git config core.hooksPath .githooks
+set -euo pipefail
+
+# Collect all staged (added/copied/modified/renamed) files.
+mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACMR)
+
+if [ "${#staged[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+# Filter to files that still exist on disk (skip e.g. submodule entries
+# or files removed after staging).
+existing=()
+for f in "${staged[@]}"; do
+  if [ -f "$f" ]; then
+    existing+=("$f")
+  fi
+done
+
+if [ "${#existing[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+echo "pre-commit: running 'nix fmt' on ${#existing[@]} staged file(s)"
+
+# treefmt-based formatter accepts a list of paths to format.
+nix fmt -- "${existing[@]}"
+
+# Re-stage any of those files that were modified by the formatter.
+to_restage=()
+for f in "${existing[@]}"; do
+  if ! git diff --quiet -- "$f"; then
+    to_restage+=("$f")
+  fi
+done
+
+if [ "${#to_restage[@]}" -gt 0 ]; then
+  echo "pre-commit: re-staging formatted files:"
+  printf '  %s\n' "${to_restage[@]}"
+  git add -- "${to_restage[@]}"
+fi

--- a/pkgs-many/db/generic.nix
+++ b/pkgs-many/db/generic.nix
@@ -22,7 +22,9 @@
   runUnitTests,
 }@args:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (
+  finalAttrs:
+  {
     pname = "db";
     inherit version;
 
@@ -117,4 +119,6 @@ stdenv.mkDerivation (finalAttrs: {
           lib.licenses.${license};
       platforms = lib.platforms.unix;
     };
-  } // drvArgs)
+  }
+  // drvArgs
+)

--- a/pkgs-many/db/generic.nix
+++ b/pkgs-many/db/generic.nix
@@ -19,10 +19,10 @@
   cxxSupport ? true,
   compat185 ? true,
   dbmSupport ? false,
+  runUnitTests,
 }@args:
 
-stdenv.mkDerivation (
-  rec {
+stdenv.mkDerivation (finalAttrs: {
     pname = "db";
     inherit version;
 
@@ -99,11 +99,11 @@ stdenv.mkDerivation (
 
     enableParallelBuilding = true;
 
-    doCheck = true;
-
     checkPhase = ''
       make examples_c examples_cxx
     '';
+
+    passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
     meta = {
       homepage = "https://www.oracle.com/database/technologies/related/berkeleydb.html";
@@ -117,6 +117,4 @@ stdenv.mkDerivation (
           lib.licenses.${license};
       platforms = lib.platforms.unix;
     };
-  }
-  // drvArgs
-)
+  } // drvArgs)

--- a/pkgs-many/fmt/generic.nix
+++ b/pkgs-many/fmt/generic.nix
@@ -13,6 +13,7 @@
   fetchpatch,
   cmake,
   enableShared ? !stdenv.hostPlatform.isStatic,
+  runUnitTests,
 
   # tests
   mpd,
@@ -21,7 +22,7 @@
   spdlog,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fmt";
   inherit version;
 
@@ -46,10 +47,9 @@ stdenv.mkDerivation {
 
   cmakeFlags = [ (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared) ];
 
-  doCheck = true;
-
   passthru = mkVariantPassthru variantArgs // {
     tests = {
+      unittests = runUnitTests finalAttrs.finalPackage;
       inherit
         mpd
         openimageio
@@ -72,4 +72,4 @@ stdenv.mkDerivation {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs-many/gmp/generic.nix
+++ b/pkgs-many/gmp/generic.nix
@@ -22,6 +22,7 @@
   m4,
   buildPackages,
   withStatic ? stdenv.hostPlatform.isStatic,
+  runUnitTests,
 }@args:
 
 let
@@ -79,11 +80,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optional (!withStatic && stdenv.hostPlatform.isWindows) "--disable-static --enable-shared"
   ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) "--disable-assembly";
 
-  doCheck = true; # not cross;
-
   dontDisableStatic = withStatic;
 
   enableParallelBuilding = true;
+
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     homepage = "https://gmplib.org/";

--- a/pkgs-many/openssl/generic.nix
+++ b/pkgs-many/openssl/generic.nix
@@ -56,6 +56,7 @@
   ),
   autoloadProviders ? needsOQSProvider,
   extraINIConfig ? (if oqsExtraINIConfig != null then oqsExtraINIConfig else null),
+  runUnitTests,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -285,7 +286,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
   preCheck = ''
     patchShebangs util
   '';
@@ -400,6 +400,7 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
   };
 

--- a/pkgs/argp-standalone/default.nix
+++ b/pkgs/argp-standalone/default.nix
@@ -4,16 +4,17 @@
   fetchFromGitHub,
   meson,
   ninja,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "argp-standalone";
   version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "argp-standalone";
     repo = "argp-standalone";
-    tag = version;
+    tag = finalAttrs.version;
     sha256 = "jWnoWVnUVDQlsC9ru7oB9PdtZuyCCNqGnMqF/f2m0ZY=";
   };
 
@@ -22,7 +23,9 @@ stdenv.mkDerivation rec {
     ninja
   ];
 
-  doCheck = true;
+  passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   meta = {
     homepage = "https://github.com/argp-standalone/argp-standalone";
@@ -30,4 +33,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     license = lib.licenses.lgpl21Plus;
   };
-}
+})

--- a/pkgs/bc/default.nix
+++ b/pkgs/bc/default.nix
@@ -9,13 +9,14 @@
   readline,
   ed,
   texinfo,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bc";
   version = "1.08.2";
   src = fetchurl {
-    url = "mirror://gnu/bc/bc-${version}.tar.lz";
+    url = "mirror://gnu/bc/bc-${finalAttrs.version}.tar.lz";
     hash = "sha256-eeMeAiqEsx3YCYFQY9S46lkLQJY3pSxQ7J9Cwr8zJxE=";
   };
 
@@ -40,12 +41,12 @@ stdenv.mkDerivation rec {
     flex
   ];
 
-  doCheck = true; # not cross
-
   # Hack to make sure we never to the relaxation `$PATH` and hooks support for
   # compatibility. This will be replaced with something clearer in a future
   # masss-rebuild.
   strictDeps = true;
+
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     description = "GNU software calculator";
@@ -54,4 +55,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     mainProgram = "bc";
   };
-}
+})

--- a/pkgs/brotli/default.nix
+++ b/pkgs/brotli/default.nix
@@ -7,6 +7,7 @@
   python3Packages,
   staticOnly ? stdenv.hostPlatform.isStatic,
   testers,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -44,8 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
   ];
 
-  doCheck = true;
-
   checkTarget = "test";
 
   # Don't bother with "man" output for now,
@@ -60,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
     python = python3Packages.brotli;
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {

--- a/pkgs/byacc/default.nix
+++ b/pkgs/byacc/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -21,11 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
     "--program-transform-name='s,^,b,'"
   ];
 
-  doCheck = true;
-
   postInstall = ''
     ln -s $out/bin/byacc $out/bin/yacc
   '';
+
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     homepage = "https://invisible-island.net/byacc/byacc.html";

--- a/pkgs/capstone/default.nix
+++ b/pkgs/capstone/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -25,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
   ];
 
-  doCheck = true;
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     description = "Advanced disassembly library";

--- a/pkgs/catch2_3/default.nix
+++ b/pkgs/catch2_3/default.nix
@@ -5,16 +5,17 @@
   cmake,
   python3,
   spdlog,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "catch2";
   version = "3.11.0";
 
   src = fetchFromGitHub {
     owner = "catchorg";
     repo = "Catch2";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7Dx7PhtRwkbo8vHF57sAns2fQZ442D3cMyCt25RvzJc=";
   };
 
@@ -38,10 +39,10 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DCATCH_DEVELOPMENT_BUILD=ON"
-    "-DCATCH_BUILD_TESTING=${if doCheck then "ON" else "OFF"}"
+    "-DCATCH_BUILD_TESTING=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     "-DCATCH_ENABLE_WERROR=OFF"
   ]
-  ++ lib.optionals (stdenv.cc.isClang && doCheck) [
+  ++ lib.optionals (stdenv.cc.isClang && finalAttrs.finalPackage.doCheck) [
     # test has a faulty path normalization technique that won't work in
     # our darwin/LLVM build environment https://github.com/catchorg/Catch2/issues/1691
     "-DCMAKE_CTEST_ARGUMENTS=-E;ApprovalTests"
@@ -57,21 +58,20 @@ stdenv.mkDerivation rec {
       NIX_CFLAGS_COMPILE = "-Wno-error=cast-align";
     };
 
-  doCheck = true;
-
   nativeCheckInputs = [
     python3
   ];
 
   passthru.tests = {
     inherit spdlog;
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
     description = "Modern, C++-native, test framework for unit-tests";
     homepage = "https://github.com/catchorg/Catch2";
-    changelog = "https://github.com/catchorg/Catch2/blob/${src.tag}/docs/release-notes.md";
+    changelog = "https://github.com/catchorg/Catch2/blob/${finalAttrs.src.tag}/docs/release-notes.md";
     license = lib.licenses.boost;
     platforms = with lib.platforms; unix ++ windows;
   };
-}
+})

--- a/pkgs/cmocka/default.nix
+++ b/pkgs/cmocka/default.nix
@@ -3,14 +3,15 @@
   lib,
   stdenv,
   cmake,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cmocka";
   version = "1.1.8";
 
   src = fetchurl {
-    url = "https://cmocka.org/files/${lib.versions.majorMinor version}/cmocka-${version}.tar.xz";
+    url = "https://cmocka.org/files/${lib.versions.majorMinor finalAttrs.version}/cmocka-${finalAttrs.version}.tar.xz";
     hash = "sha256-WENbVYdm1/THKboWO9867Di+07x2batoTjUm7Qqnx4A=";
   };
 
@@ -24,10 +25,12 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags =
-    lib.optional doCheck "-DUNIT_TESTING=ON"
+    lib.optional finalAttrs.finalPackage.doCheck "-DUNIT_TESTING=ON"
     ++ lib.optional stdenv.hostPlatform.isStatic "-DBUILD_SHARED_LIBS=OFF";
 
-  doCheck = true;
+  passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Lightweight library to simplify and generalize unit tests for C";
@@ -60,4 +63,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/dbus/default.nix
+++ b/pkgs/dbus/default.nix
@@ -17,14 +17,15 @@
   x11Support ? (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin),
   xorg,
   libx11,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dbus";
   version = "1.14.10";
 
   src = fetchurl {
-    url = "https://dbus.freedesktop.org/releases/dbus/dbus-${version}.tar.xz";
+    url = "https://dbus.freedesktop.org/releases/dbus/dbus-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-uh8h0r2dM52i1KqHgMCd8y/qh5mLc9ok9Jq53x42pQ8=";
   };
 
@@ -112,8 +113,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
-
   makeFlags = [
     # Fix paths in XML catalog broken by mismatching build/install datadir.
     "dtddir=${placeholder "out"}/share/xml/dbus-1"
@@ -132,13 +131,17 @@ stdenv.mkDerivation rec {
 
   passthru = {
     dbus-launch = "${dbus.lib}/bin/dbus-launch";
+
+    tests = {
+      unittests = runUnitTests finalAttrs.finalPackage;
+    };
   };
 
   meta = {
     description = "Simple interprocess messaging system";
     homepage = "https://www.freedesktop.org/wiki/Software/dbus/";
-    changelog = "https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-${version}/NEWS";
+    changelog = "https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Plus; # most is also under AFL-2.1
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/doctest/default.nix
+++ b/pkgs/doctest/default.nix
@@ -4,16 +4,17 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "doctest";
   version = "2.4.12";
 
   src = fetchFromGitHub {
     owner = "doctest";
     repo = "doctest";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Fxs1EWydhqN9whx+Cn4fnZ4fhCEQvFgL5e9TUiXlnq8=";
   };
 
@@ -38,7 +39,9 @@ stdenv.mkDerivation rec {
     "-DDOCTEST_WITH_TESTS=OFF"
   ];
 
-  doCheck = true;
+  passthru.tests = lib.optionalAttrs (!stdenv.hostPlatform.isStatic) {
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   # Fix the build with LLVM 21 / GCC 15.
   #
@@ -58,4 +61,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/dosfstools/default.nix
+++ b/pkgs/dosfstools/default.nix
@@ -8,6 +8,7 @@
   libiconv,
   gettext,
   xxd,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -58,7 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeCheckInputs = [ xxd ];
-  doCheck = true;
+
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     description = "Utilities for creating and checking FAT and VFAT file systems";

--- a/pkgs/e2fsprogs/default.nix
+++ b/pkgs/e2fsprogs/default.nix
@@ -16,16 +16,17 @@
   libarchive,
   bash,
   bashNonInteractive,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "e2fsprogs";
   version = "1.47.3";
 
   __structuredAttrs = true;
 
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/people/tytso/e2fsprogs/v${version}/e2fsprogs-${version}.tar.xz";
+    url = "mirror://kernel/linux/kernel/people/tytso/e2fsprogs/v${finalAttrs.version}/e2fsprogs-${finalAttrs.version}.tar.xz";
     hash = "sha256-hX5u+AD+qiu0V4+8gQIUvl08iLBy6lPFOEczqWVzcyk=";
   };
 
@@ -87,12 +88,11 @@ stdenv.mkDerivation rec {
   ];
 
   nativeCheckInputs = [ buildPackages.perl ];
-  doCheck = true;
 
   postInstall = ''
     # avoid cycle between outputs
-    if [ -f $out/lib/${pname}/e2scrub_all_cron ]; then
-      mv $out/lib/${pname}/e2scrub_all_cron $bin/bin/
+    if [ -f $out/lib/${finalAttrs.pname}/e2scrub_all_cron ]; then
+      mv $out/lib/${finalAttrs.pname}/e2scrub_all_cron $bin/bin/
     fi
 
     moveToOutput bin/mk_cmds "$scripts"
@@ -127,11 +127,12 @@ stdenv.mkDerivation rec {
       ${e2fsprogs}/bin/e2fsck -n $out/disc | tee $out/success
       [ -e $out/success ]
     '';
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
     homepage = "https://e2fsprogs.sourceforge.net/";
-    changelog = "https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#${version}";
+    changelog = "https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#${finalAttrs.version}";
     description = "Tools for creating and checking ext2/ext3/ext4 filesystems";
     license = with lib.licenses; [
       gpl2Plus
@@ -141,4 +142,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/ed/default.nix
+++ b/pkgs/ed/default.nix
@@ -5,6 +5,7 @@
   runtimeShellPackage,
   stdenv,
   testers,
+  runUnitTests,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus cannot use
@@ -31,12 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  doCheck = true;
-
   passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      command = "ed --version";
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "ed --version";
+      };
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
   };
 

--- a/pkgs/expat/default.nix
+++ b/pkgs/expat/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   updateAutotoolsGnuConfigScriptsHook,
+  runUnitTests,
   # for passthru.tests
   python3,
   perlPackages,
@@ -47,8 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputMan = "dev"; # tiny page for a dev tool
 
-  doCheck = true; # not cross;
-
   preCheck = ''
     patchShebangs ./run.sh ./test-driver-wrapper.sh
   '';
@@ -61,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
     inherit python3;
     inherit (python3.pkgs) xmltodict;
     inherit (haskellPackages) hexpat;

--- a/pkgs/fontconfig/default.nix
+++ b/pkgs/fontconfig/default.nix
@@ -13,6 +13,7 @@
   versionCheckHook,
   testers,
   gitUpdater,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -71,8 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
-
   installFlags = [
     # Don't try to write to /var/cache/fontconfig at install time.
     "fc_cachedir=$(TMPDIR)/dummy"
@@ -112,6 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
+      unittests = runUnitTests finalAttrs.finalPackage;
       pkg-config = testers.hasPkgConfigModules {
         package = finalAttrs.finalPackage;
       };

--- a/pkgs/freetype/default.nix
+++ b/pkgs/freetype/default.nix
@@ -13,6 +13,7 @@
   libpng,
   gnumake,
   glib,
+  runUnitTests,
 
   # FreeType supports LCD filtering (colloquially referred to as sub-pixel rendering).
   # LCD filtering is also known as ClearType and covered by several Microsoft patents.
@@ -92,8 +93,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
-
   # pkgsCross.mingwW64.pkg-config doesn't build
   # makeWrapper doesn't cross-compile to windows #120726
   postInstall = ''
@@ -107,6 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
     inherit
       cairo
       fontforge

--- a/pkgs/gdbm/default.nix
+++ b/pkgs/gdbm/default.nix
@@ -4,6 +4,7 @@
   stdenv,
   testers,
   updateAutotoolsGnuConfigScriptsHook,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,8 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
     "man"
   ];
-
-  doCheck = true;
 
   enableParallelBuilding = true;
 
@@ -57,9 +56,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      command = "gdbmtool --version";
+    tests = {
+      unittests = runUnitTests finalAttrs.finalPackage;
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "gdbmtool --version";
+      };
     };
   };
 

--- a/pkgs/gmp/6.x.nix
+++ b/pkgs/gmp/6.x.nix
@@ -6,6 +6,7 @@
   cxx ? !stdenv.hostPlatform.useAndroidPrebuilt && !stdenv.hostPlatform.isWasm,
   buildPackages,
   withStatic ? stdenv.hostPlatform.isStatic,
+  runUnitTests,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -17,97 +18,95 @@ let
   inherit (lib) optional;
 in
 
-let
-  self = stdenv.mkDerivation rec {
-    pname = "gmp${lib.optionalString cxx "-with-cxx"}";
-    version = "6.3.0";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gmp${lib.optionalString cxx "-with-cxx"}";
+  version = "6.3.0";
 
-    src = fetchurl {
-      # we need to use bz2, others aren't in bootstrapping stdenv
-      urls = [
-        "mirror://gnu/gmp/gmp-${version}.tar.bz2"
-        "ftp://ftp.gmplib.org/pub/gmp-${version}/gmp-${version}.tar.bz2"
-      ];
-      hash = "sha256-rCghGnz7YJuuLiyNYFjWbI/pZDT3QM9v4uR7AA0cIMs=";
-    };
-
-    #outputs TODO: split $cxx due to libstdc++ dependency
-    # maybe let ghc use a version with *.so shared with rest of nixpkgs and *.a added
-    # - see #5855 for related discussion
-    outputs = [
-      "out"
-      "dev"
-      "info"
+  src = fetchurl {
+    # we need to use bz2, others aren't in bootstrapping stdenv
+    urls = [
+      "mirror://gnu/gmp/gmp-${finalAttrs.version}.tar.bz2"
+      "ftp://ftp.gmplib.org/pub/gmp-${finalAttrs.version}/gmp-${finalAttrs.version}.tar.bz2"
     ];
-    passthru.static = self.out;
-
-    strictDeps = true;
-    depsBuildBuild = [ buildPackages.stdenv.cc ];
-    nativeBuildInputs = [ m4 ];
-
-    configureFlags = [
-      "--with-pic"
-      # gcc-15 have c23 standard by default, where "void foo()" now means "void foo(void)".
-      #
-      # The "configure" script relies on c17 and below semantics for "long long
-      # reliability test 1" (defined in aclocal.m4)
-      "CFLAGS=-std=c99"
-
-      (lib.enableFeature cxx "cxx")
-      # Build a "fat binary", with routines for several sub-architectures
-      # (x86), except on Solaris where some tests crash with "Memory fault".
-      # See <https://hydra.nixos.org/build/2760931>, for instance.
-      #
-      # no darwin because gmp uses ASM that clang doesn't like
-      (lib.enableFeature (!stdenv.hostPlatform.isSunOS && stdenv.hostPlatform.isx86) "fat")
-      # The config.guess in GMP tries to runtime-detect various
-      # ARM optimization flags via /proc/cpuinfo (and is also
-      # broken on multicore CPUs). Avoid this impurity.
-      "--build=${stdenv.buildPlatform.config}"
-    ]
-    ++ optional (cxx && stdenv.hostPlatform.isDarwin) "CPPFLAGS=-fexceptions"
-    ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.is64bit) "ABI=64"
-    # to build a .dll on windows, we need --disable-static + --enable-shared
-    # see https://gmplib.org/manual/Notes-for-Particular-Systems.html
-    ++ optional (!withStatic && stdenv.hostPlatform.isWindows) "--disable-static --enable-shared"
-    ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) "--disable-assembly";
-
-    doCheck = true; # not cross;
-
-    dontDisableStatic = withStatic;
-
-    enableParallelBuilding = true;
-
-    meta = {
-      homepage = "https://gmplib.org/";
-      description = "GNU multiple precision arithmetic library";
-      license = with lib.licenses; [
-        lgpl3Only
-        gpl2Only
-      ];
-      longDescription = ''
-        GMP is a free library for arbitrary precision arithmetic, operating
-        on signed integers, rational numbers, and floating point numbers.
-        There is no practical limit to the precision except the ones implied
-        by the available memory in the machine GMP runs on.  GMP has a rich
-        set of functions, and the functions have a regular interface.
-
-        The main target applications for GMP are cryptography applications
-        and research, Internet security applications, algebra systems,
-        computational algebra research, etc.
-
-        GMP is carefully designed to be as fast as possible, both for small
-        operands and for huge operands.  The speed is achieved by using
-        fullwords as the basic arithmetic type, by using fast algorithms,
-        with highly optimised assembly code for the most common inner loops
-        for a lot of CPUs, and by a general emphasis on speed.
-
-        GMP is faster than any other bignum library.  The advantage for GMP
-        increases with the operand sizes for many operations, since GMP uses
-        asymptotically faster algorithms.
-      '';
-      platforms = lib.platforms.all;
-    };
+    hash = "sha256-rCghGnz7YJuuLiyNYFjWbI/pZDT3QM9v4uR7AA0cIMs=";
   };
-in
-self
+
+  #outputs TODO: split $cxx due to libstdc++ dependency
+  # maybe let ghc use a version with *.so shared with rest of nixpkgs and *.a added
+  # - see #5855 for related discussion
+  outputs = [
+    "out"
+    "dev"
+    "info"
+  ];
+  passthru = {
+    static = finalAttrs.finalPackage.out;
+    tests.unittests = runUnitTests finalAttrs.finalPackage;
+  };
+
+  strictDeps = true;
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ m4 ];
+
+  configureFlags = [
+    "--with-pic"
+    # gcc-15 have c23 standard by default, where "void foo()" now means "void foo(void)".
+    #
+    # The "configure" script relies on c17 and below semantics for "long long
+    # reliability test 1" (defined in aclocal.m4)
+    "CFLAGS=-std=c99"
+
+    (lib.enableFeature cxx "cxx")
+    # Build a "fat binary", with routines for several sub-architectures
+    # (x86), except on Solaris where some tests crash with "Memory fault".
+    # See <https://hydra.nixos.org/build/2760931>, for instance.
+    #
+    # no darwin because gmp uses ASM that clang doesn't like
+    (lib.enableFeature (!stdenv.hostPlatform.isSunOS && stdenv.hostPlatform.isx86) "fat")
+    # The config.guess in GMP tries to runtime-detect various
+    # ARM optimization flags via /proc/cpuinfo (and is also
+    # broken on multicore CPUs). Avoid this impurity.
+    "--build=${stdenv.buildPlatform.config}"
+  ]
+  ++ optional (cxx && stdenv.hostPlatform.isDarwin) "CPPFLAGS=-fexceptions"
+  ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.is64bit) "ABI=64"
+  # to build a .dll on windows, we need --disable-static + --enable-shared
+  # see https://gmplib.org/manual/Notes-for-Particular-Systems.html
+  ++ optional (!withStatic && stdenv.hostPlatform.isWindows) "--disable-static --enable-shared"
+  ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) "--disable-assembly";
+
+  dontDisableStatic = withStatic;
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "https://gmplib.org/";
+    description = "GNU multiple precision arithmetic library";
+    license = with lib.licenses; [
+      lgpl3Only
+      gpl2Only
+    ];
+    longDescription = ''
+      GMP is a free library for arbitrary precision arithmetic, operating
+      on signed integers, rational numbers, and floating point numbers.
+      There is no practical limit to the precision except the ones implied
+      by the available memory in the machine GMP runs on.  GMP has a rich
+      set of functions, and the functions have a regular interface.
+
+      The main target applications for GMP are cryptography applications
+      and research, Internet security applications, algebra systems,
+      computational algebra research, etc.
+
+      GMP is carefully designed to be as fast as possible, both for small
+      operands and for huge operands.  The speed is achieved by using
+      fullwords as the basic arithmetic type, by using fast algorithms,
+      with highly optimised assembly code for the most common inner loops
+      for a lot of CPUs, and by a general emphasis on speed.
+
+      GMP is faster than any other bignum library.  The advantage for GMP
+      increases with the operand sizes for many operations, since GMP uses
+      asymptotically faster algorithms.
+    '';
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/groff/default.nix
+++ b/pkgs/groff/default.nix
@@ -23,14 +23,15 @@
   texinfo,
   bison,
   bashNonInteractive,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "groff";
   version = "1.23.0";
 
   src = fetchurl {
-    url = "mirror://gnu/groff/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/groff/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     hash = "sha256-a5dX9ZK3UYtJAutq9+VFcL3Mujeocf3bLTCuOGNRHBM=";
   };
 
@@ -119,7 +120,7 @@ stdenv.mkDerivation rec {
     "GROFFBIN=${buildPackages.groff}/bin/groff"
   ];
 
-  doCheck = true;
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   postInstall = ''
     for f in 'man.local' 'mdoc.local'; do
@@ -175,4 +176,4 @@ stdenv.mkDerivation rec {
       "perl"
     ];
   };
-}
+})

--- a/pkgs/json-glib/default.nix
+++ b/pkgs/json-glib/default.nix
@@ -19,9 +19,10 @@
   libxslt,
   fixDarwinDylibNames,
   gnome,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "json-glib";
   version = "1.10.8";
 
@@ -33,7 +34,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional withIntrospection "devdoc";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/${finalAttrs.pname}/${lib.versions.majorMinor finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     hash = "sha256-VcXBQaVkJFuPj752mGY8h6RaczPCosVvBvgRq3OyEt0=";
   };
 
@@ -79,8 +80,6 @@ stdenv.mkDerivation rec {
     (lib.mesonEnable "documentation" withIntrospection)
   ];
 
-  doCheck = true;
-
   postFixup = ''
     # Move developer documentation to devdoc output.
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
@@ -95,10 +94,11 @@ stdenv.mkDerivation rec {
   passthru = {
     tests = {
       installedTests = nixosTests.installed-tests.json-glib;
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
 
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = finalAttrs.pname;
       versionPolicy = "odd-unstable";
     };
   };
@@ -109,4 +109,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl21Plus;
     platforms = with lib.platforms; unix;
   };
-}
+})

--- a/pkgs/lapack-reference/default.nix
+++ b/pkgs/lapack-reference/default.nix
@@ -8,6 +8,7 @@
   # Compile with ILP64 interface
   blas64 ? false,
   testers,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -62,8 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
       ln -s $out/lib/liblapacke64${canonicalExtension} $out/lib/liblapacke${canonicalExtension}
     '';
 
-  doCheck = true;
-
   # Some CBLAS related tests fail on Darwin:
   #  14 - CBLAS-xscblat2 (Failed)
   #  15 - CBLAS-xscblat3 (Failed)
@@ -84,7 +83,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Linear Algebra PACKage";

--- a/pkgs/libassuan/default.nix
+++ b/pkgs/libassuan/default.nix
@@ -7,14 +7,15 @@
   libgpg-error,
   buildPackages,
   gitUpdater,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libassuan";
   version = "3.0.2";
 
   src = fetchurl {
-    url = "mirror://gnupg/libassuan/libassuan-${version}.tar.bz2";
+    url = "mirror://gnupg/libassuan/libassuan-${finalAttrs.version}.tar.bz2";
     hash = "sha256-0pMc2tJm5jNRD5lw4aLzRgVeNRuxn5t4kSR1uAdMNvY=";
   };
 
@@ -36,17 +37,18 @@ stdenv.mkDerivation rec {
     "--with-libgpg-error-prefix=${libgpg-error.dev}"
   ];
 
-  doCheck = true;
-
   # Make sure includes are fixed for callers who don't use libassuan-config
   postInstall = ''
     sed -i 's,#include <gpg-error.h>,#include "${libgpg-error.dev}/include/gpg-error.h",g' $dev/include/assuan.h
   '';
 
-  passthru.updateScript = gitUpdater {
-    url = "https://dev.gnupg.org/source/libassuan.git";
-    rev-prefix = "libassuan-";
-    ignoredVersions = ".*-base";
+  passthru = {
+    updateScript = gitUpdater {
+      url = "https://dev.gnupg.org/source/libassuan.git";
+      rev-prefix = "libassuan-";
+      ignoredVersions = ".*-base";
+    };
+    tests.unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
@@ -59,8 +61,8 @@ stdenv.mkDerivation rec {
       provided.
     '';
     homepage = "https://gnupg.org/software/libassuan/";
-    changelog = "https://dev.gnupg.org/source/libassuan/browse/master/NEWS;libassuan-${version}";
+    changelog = "https://dev.gnupg.org/source/libassuan/browse/master/NEWS;libassuan-${finalAttrs.version}";
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/libbsd/default.nix
+++ b/pkgs/libbsd/default.nix
@@ -5,14 +5,15 @@
   autoreconfHook,
   libmd,
   gitUpdater,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libbsd";
   version = "0.12.2";
 
   src = fetchurl {
-    url = "https://libbsd.freedesktop.org/releases/${pname}-${version}.tar.xz";
+    url = "https://libbsd.freedesktop.org/releases/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     hash = "sha256-uIzJFj0MZSqvOamZkdl03bocOpcR248bWDivKhRzEBQ=";
   };
 
@@ -24,8 +25,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
-
   nativeBuildInputs = [ autoreconfHook ];
   propagatedBuildInputs = [ libmd ];
 
@@ -35,9 +34,15 @@ stdenv.mkDerivation rec {
     ./darwin-enable-strtonum.patch
   ];
 
-  passthru.updateScript = gitUpdater {
-    # No nicer place to find latest release.
-    url = "https://gitlab.freedesktop.org/libbsd/libbsd.git";
+  passthru = {
+    updateScript = gitUpdater {
+      # No nicer place to find latest release.
+      url = "https://gitlab.freedesktop.org/libbsd/libbsd.git";
+    };
+
+    tests = {
+      unittests = runUnitTests finalAttrs.finalPackage;
+    };
   };
 
   # Fix undefined reference errors with version script under LLVM.
@@ -60,4 +65,4 @@ stdenv.mkDerivation rec {
     # See architectures defined in src/local-elf.h.
     badPlatforms = lib.platforms.microblaze;
   };
-}
+})

--- a/pkgs/libcap_ng/default.nix
+++ b/pkgs/libcap_ng/default.nix
@@ -6,6 +6,7 @@
   swig,
   testers,
   nix-update-script,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -45,14 +46,11 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
     tests = {
+      unittests = runUnitTests finalAttrs.finalPackage;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
     };
   };
-
-  # assumption: build machine runs linux kernel 5.0 or newer
-  # see https://github.com/stevegrubb/libcap-ng?tab=readme-ov-file#note-to-distributions
-  doCheck = true;
 
   meta = {
     changelog = "https://people.redhat.com/sgrubb/libcap-ng/ChangeLog";

--- a/pkgs/libdeflate/default.nix
+++ b/pkgs/libdeflate/default.nix
@@ -7,6 +7,7 @@
   cmake,
   zlib,
   testers,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -37,9 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
     };
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
-
-  doCheck = true;
 
   meta = {
     description = "Fast DEFLATE/zlib/gzip compressor and decompressor";

--- a/pkgs/libdex/default.nix
+++ b/pkgs/libdex/default.nix
@@ -11,6 +11,7 @@
   glib,
   liburing,
   gnome,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -46,16 +47,17 @@ stdenv.mkDerivation (finalAttrs: {
     "-Ddocs=true"
   ];
 
-  doCheck = true;
-
   postFixup = ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
     moveToOutput "share/doc" "$devdoc"
   '';
 
-  passthru.updateScript = gnome.updateScript {
-    packageName = "libdex";
-    versionPolicy = "odd-unstable";
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = "libdex";
+      versionPolicy = "odd-unstable";
+    };
+    tests.unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {

--- a/pkgs/libepoxy/default.nix
+++ b/pkgs/libepoxy/default.nix
@@ -11,6 +11,7 @@
   libx11,
   x11Support ? !stdenv.hostPlatform.isDarwin,
   testers,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -74,9 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
     x11Support && !stdenv.hostPlatform.isDarwin
   ) ''-DLIBGL_PATH="${lib.getLib libGL}/lib"'';
 
-  doCheck = true;
-
   passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
     pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
     };

--- a/pkgs/libgcrypt/default.nix
+++ b/pkgs/libgcrypt/default.nix
@@ -7,6 +7,7 @@
   enableCapabilities ? false,
   libcap,
   buildPackages,
+  runUnitTests,
 
   # for passthru.tests. Don't force these to be available in corepkgs
   gnupg,
@@ -16,12 +17,12 @@
 
 assert enableCapabilities -> stdenv.hostPlatform.isLinux;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libgcrypt";
   version = "1.11.2";
 
   src = fetchurl {
-    url = "mirror://gnupg/libgcrypt/${pname}-${version}.tar.bz2";
+    url = "mirror://gnupg/libgcrypt/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
     hash = "sha256-a6Wd0ZInDowdIt20GgfZXc28Hw+wLQPEtUsjWBQzCqw=";
   };
 
@@ -112,18 +113,18 @@ stdenv.mkDerivation rec {
     cp src/.libs/libgcrypt.20.dylib $lib/lib
   '';
 
-  doCheck = true;
   enableParallelChecking = true;
 
   passthru.tests = {
     inherit gnupg libotr rsyslog;
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
     homepage = "https://www.gnu.org/software/libgcrypt/";
-    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=${pname}.git;a=blob;f=NEWS;hb=refs/tags/${pname}-${version}";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=${finalAttrs.pname}.git;a=blob;f=NEWS;hb=refs/tags/${finalAttrs.pname}-${finalAttrs.version}";
     description = "General-purpose cryptographic library";
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/libgit2/default.nix
+++ b/pkgs/libgit2/default.nix
@@ -11,6 +11,7 @@
   pcre2,
   libiconv,
   staticBuild ? stdenv.hostPlatform.isStatic,
+  runUnitTests,
   # for passthru.tests
   libgit2-glib,
   python3Packages,
@@ -73,7 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = lib.optional (!stdenv.hostPlatform.isLinux) libiconv;
 
-  doCheck = true;
   checkPhase = ''
     testArgs=(-v -xonline)
 
@@ -90,7 +90,10 @@ stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
-  passthru.tests = lib.mapAttrs (_: v: v.override { libgit2 = finalAttrs.finalPackage; }) {
+  passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
+  }
+  // lib.mapAttrs (_: v: v.override { libgit2 = finalAttrs.finalPackage; }) {
     inherit libgit2-glib;
     inherit (python3Packages) pygit2;
     inherit (gitstatus) romkatv_libgit2;

--- a/pkgs/libgpg-error/default.nix
+++ b/pkgs/libgpg-error/default.nix
@@ -5,6 +5,7 @@
   fetchurl,
   gettext,
   genPosixLockObjOnly ? false,
+  runUnitTests,
 }:
 let
   genPosixLockObjOnlyAttrs = lib.optionalAttrs genPosixLockObjOnly {
@@ -23,12 +24,16 @@ let
   };
 in
 stdenv.mkDerivation (
-  rec {
+  finalAttrs:
+  let
+    genPosixLockObjOnlyAttrs' = genPosixLockObjOnlyAttrs;
+  in
+  {
     pname = "libgpg-error";
     version = "1.55";
 
     src = fetchurl {
-      url = "mirror://gnupg/${pname}/${pname}-${version}.tar.bz2";
+      url = "mirror://gnupg/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
       hash = "sha256-lbF4FIhj8H1F3wzqZ+iAp5ue9x9dIwut3ABxEoUW73g=";
     };
 
@@ -72,11 +77,11 @@ stdenv.mkDerivation (
         echo '#undef USE_POSIX_THREADS_WEAK' >> config.h
       '';
 
-    doCheck = true; # not cross
+    passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
     meta = {
       homepage = "https://www.gnupg.org/software/libgpg-error/index.html";
-      changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=NEWS;hb=refs/tags/libgpg-error-${version}";
+      changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=NEWS;hb=refs/tags/libgpg-error-${finalAttrs.version}";
       description = "Small library that defines common error values for all GnuPG components";
       mainProgram = "gen-posix-lock-obj";
       longDescription = ''
@@ -89,5 +94,5 @@ stdenv.mkDerivation (
       platforms = lib.platforms.all;
     };
   }
-  // genPosixLockObjOnlyAttrs
+  // genPosixLockObjOnlyAttrs'
 )

--- a/pkgs/libmd/default.nix
+++ b/pkgs/libmd/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   autoreconfHook,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,9 +20,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
-
   nativeBuildInputs = [ autoreconfHook ];
+
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     homepage = "https://www.hadrons.org/software/libmd/";

--- a/pkgs/libmpc/default.nix
+++ b/pkgs/libmpc/default.nix
@@ -5,6 +5,7 @@
   gmp,
   mpfr,
   updateAutotoolsGnuConfigScriptsHook,
+  runUnitTests,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -12,12 +13,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libmpc";
   version = "1.3.1"; # to avoid clash with the MPD client
 
   src = fetchurl {
-    url = "mirror://gnu/mpc/mpc-${version}.tar.gz";
+    url = "mirror://gnu/mpc/mpc-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-q2QkkvXPiCt0qgy3MM1BCoHtzb7IlRg86TDnBsHHWbg=";
   };
 
@@ -33,7 +34,7 @@ stdenv.mkDerivation rec {
     updateAutotoolsGnuConfigScriptsHook
   ];
 
-  doCheck = true; # not cross;
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     description = "Library for multiprecision complex arithmetic with exact rounding";
@@ -46,4 +47,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/libpng/default.nix
+++ b/pkgs/libpng/default.nix
@@ -5,6 +5,7 @@
   zlib,
   apngSupport ? true,
   testers,
+  runUnitTests,
 }:
 
 assert zlib != null;
@@ -42,14 +43,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [ zlib ];
 
-  doCheck = true;
-
   passthru = {
     inherit zlib;
 
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
   };
 

--- a/pkgs/libpsl/default.nix
+++ b/pkgs/libpsl/default.nix
@@ -14,14 +14,15 @@
   pkg-config,
   buildPackages,
   publicsuffix-list,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libpsl";
   version = "0.21.5";
 
   src = fetchurl {
-    url = "https://github.com/rockdaboot/libpsl/releases/download/${version}/libpsl-${version}.tar.lz";
+    url = "https://github.com/rockdaboot/libpsl/releases/download/${finalAttrs.version}/libpsl-${finalAttrs.version}.tar.lz";
     hash = "sha256-mp9qjG7bplDPnqVUdc0XLdKEhzFoBOnHMgLZdXLNOi0=";
   };
 
@@ -81,7 +82,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
+  passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "C library for the Publix Suffix List";
@@ -93,10 +96,10 @@ stdenv.mkDerivation rec {
       the domain in a user interface or sorting domain lists by site.
     '';
     homepage = "https://rockdaboot.github.io/libpsl/";
-    changelog = "https://raw.githubusercontent.com/rockdaboot/libpsl/libpsl-${version}/NEWS";
+    changelog = "https://raw.githubusercontent.com/rockdaboot/libpsl/libpsl-${finalAttrs.version}/NEWS";
     license = lib.licenses.mit;
     mainProgram = "psl";
     platforms = lib.platforms.unix ++ lib.platforms.windows;
     pkgConfigModules = [ "libpsl" ];
   };
-}
+})

--- a/pkgs/libsodium/default.nix
+++ b/pkgs/libsodium/default.nix
@@ -4,6 +4,7 @@
   fetchurl,
   autoreconfHook,
   testers,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -35,11 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
     stdenv.hostPlatform.isMusl && stdenv.hostPlatform.isx86_32
   ) "--disable-ssp";
 
-  doCheck = true;
-
   passthru.tests = {
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {

--- a/pkgs/libtasn1/default.nix
+++ b/pkgs/libtasn1/default.nix
@@ -9,14 +9,15 @@
   gnutls,
   samba,
   qemu,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtasn1";
   version = "4.20.0";
 
   src = fetchurl {
-    url = "mirror://gnu/libtasn1/libtasn1-${version}.tar.gz";
+    url = "mirror://gnu/libtasn1/libtasn1-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-kuDjvUwC1K7udgNrLd2D8McyukzaXLcdWDJysjWHp2w=";
   };
 
@@ -32,12 +33,12 @@ stdenv.mkDerivation rec {
     perl
   ];
 
-  doCheck = true;
   preCheck =
     if stdenv.hostPlatform.isDarwin then "export DYLD_LIBRARY_PATH=`pwd`/lib/.libs" else null;
 
   passthru.tests = {
     inherit gnutls samba qemu;
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
@@ -50,6 +51,6 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
-    changelog = "https://gitlab.com/gnutls/libtasn1/-/blob/v${version}/NEWS";
+    changelog = "https://gitlab.com/gnutls/libtasn1/-/blob/v${finalAttrs.version}/NEWS";
   };
-}
+})

--- a/pkgs/libtiff/default.nix
+++ b/pkgs/libtiff/default.nix
@@ -33,6 +33,7 @@
   gdal,
   openimageio,
   testers,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -100,8 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
-
   # Avoid flakiness like https://gitlab.com/libtiff/libtiff/-/commit/94f6f7315b1
   enableParallelChecking = false;
 
@@ -120,6 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
       pkg-config = testers.hasPkgConfigModules {
         package = finalAttrs.finalPackage;
       };
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
     updateScript = nix-update-script { };
   };

--- a/pkgs/libxcrypt/default.nix
+++ b/pkgs/libxcrypt/default.nix
@@ -8,6 +8,7 @@
   nixosTests,
   runCommand,
   python3,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -57,8 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
-
   passthru = {
     tests = {
       inherit (nixosTests) login shadow;
@@ -76,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
         }
         touch "$out"
       '';
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
     enabledCryptSchemeIds = [
       # https://github.com/besser82/libxcrypt/blob/v4.5.0/lib/hashes.conf

--- a/pkgs/linux/pkgs/systemd/default.nix
+++ b/pkgs/linux/pkgs/systemd/default.nix
@@ -18,6 +18,7 @@
   glibcLocales,
   autoPatchelfHook,
   fetchpatch,
+  runUnitTests,
 
   # glib is only used during tests (test-bus-gvariant, test-bus-marshal)
   glib,
@@ -789,8 +790,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   );
 
-  doCheck = true;
-
   # trigger the test -n "$DESTDIR" || mutate in upstreams build system
   preInstall = ''
     export DESTDIR=/
@@ -1006,6 +1005,8 @@ stdenv.mkDerivation (finalAttrs: {
       in
       relevantNixosTests
       // {
+        unittests = runUnitTests finalAttrs.finalPackage;
+
         cross =
           let
             systemString = if stdenv.buildPlatform.isAarch64 then "gnu64" else "aarch64-multiplatform";

--- a/pkgs/lzip/default.nix
+++ b/pkgs/lzip/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  runUnitTests,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -9,7 +10,7 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lzip";
   version = "1.25";
   outputs = [
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "mirror://savannah/lzip/${pname}-${version}.tar.gz";
+    url = "mirror://savannah/lzip/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     hash = "sha256-CUGKbY+4P1ET9b2FbglwPfXTe64DCMZo0PNG49PwpW8=";
   };
 
@@ -36,8 +37,9 @@ stdenv.mkDerivation rec {
 
   setupHook = ./lzip-setup-hook.sh;
 
-  doCheck = true;
   enableParallelBuilding = true;
+
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     homepage = "https://www.nongnu.org/lzip/lzip.html";
@@ -46,4 +48,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     mainProgram = "lzip";
   };
-}
+})

--- a/pkgs/lzo/default.nix
+++ b/pkgs/lzo/default.nix
@@ -3,14 +3,15 @@
   stdenv,
   fetchurl,
   updateAutotoolsGnuConfigScriptsHook,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lzo";
   version = "2.10";
 
   src = fetchurl {
-    url = "https://www.oberhumer.com/opensource/lzo/download/${pname}-${version}.tar.gz";
+    url = "https://www.oberhumer.com/opensource/lzo/download/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "0wm04519pd3g8hqpjqhfr72q8qmbiwqaxcs3cndny9h86aa95y60";
   };
 
@@ -20,9 +21,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true; # not cross;
-
   strictDeps = true;
+
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     description = "Real-time data (de)compression library";
@@ -39,4 +40,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/mpfr/default.nix
+++ b/pkgs/mpfr/default.nix
@@ -5,6 +5,7 @@
   gmp,
   writeScript,
   updateAutotoolsGnuConfigScriptsHook,
+  runUnitTests,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -12,14 +13,14 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "4.2.2";
   pname = "mpfr";
 
   src = fetchurl {
     urls = [
-      "https://www.mpfr.org/${pname}-${version}/${pname}-${version}.tar.xz"
-      "mirror://gnu/mpfr/${pname}-${version}.tar.xz"
+      "https://www.mpfr.org/${finalAttrs.pname}-${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz"
+      "mirror://gnu/mpfr/${finalAttrs.pname}-${finalAttrs.version}.tar.xz"
     ];
     hash = "sha256-tnugOD736KhWNzTi6InvXsPDuJigHQD6CmhprYHGzgE=";
   };
@@ -52,8 +53,6 @@ stdenv.mkDerivation rec {
       "--disable-decimal-float"
     ];
 
-  doCheck = true; # not cross;
-
   enableParallelBuilding = true;
 
   passthru = {
@@ -66,8 +65,9 @@ stdenv.mkDerivation rec {
       # Expect the text in format of '<title>GNU MPFR version 4.1.1</title>'
       new_version="$(curl -s https://www.mpfr.org/mpfr-current/ |
           pcregrep -o1 '<title>GNU MPFR version ([0-9.]+)</title>')"
-      update-source-version ${pname} "$new_version"
+      update-source-version ${finalAttrs.pname} "$new_version"
     '';
+    tests.unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
@@ -87,4 +87,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/nasm/default.nix
+++ b/pkgs/nasm/default.nix
@@ -4,22 +4,21 @@
   fetchurl,
   perl,
   gitUpdater,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nasm";
   version = "2.16.03";
 
   src = fetchurl {
-    url = "https://www.nasm.us/pub/nasm/releasebuilds/${version}/${pname}-${version}.tar.xz";
+    url = "https://www.nasm.us/pub/nasm/releasebuilds/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     hash = "sha256-FBKhx2C70F2wJrbA0WV6/9ZjHNCmPN229zzG1KphYUg=";
   };
 
   nativeBuildInputs = [ perl ];
 
   enableParallelBuilding = true;
-
-  doCheck = true;
 
   checkPhase = ''
     runHook preCheck
@@ -30,10 +29,13 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  passthru.updateScript = gitUpdater {
-    url = "https://github.com/netwide-assembler/nasm.git";
-    rev-prefix = "nasm-";
-    ignoredVersions = "rc.*";
+  passthru = {
+    updateScript = gitUpdater {
+      url = "https://github.com/netwide-assembler/nasm.git";
+      rev-prefix = "nasm-";
+      ignoredVersions = "rc.*";
+    };
+    tests.unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
@@ -43,4 +45,4 @@ stdenv.mkDerivation rec {
     mainProgram = "nasm";
     license = lib.licenses.bsd2;
   };
-}
+})

--- a/pkgs/nghttp3/default.nix
+++ b/pkgs/nghttp3/default.nix
@@ -4,6 +4,7 @@
   fetchurl,
   cmake,
   curl,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,9 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ENABLE_STATIC_LIB" stdenv.hostPlatform.isStatic)
   ];
 
-  doCheck = true;
-
   passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
     inherit curl;
   };
 

--- a/pkgs/ngtcp2/default.nix
+++ b/pkgs/ngtcp2/default.nix
@@ -10,6 +10,7 @@
   withJemalloc ? false,
   jemalloc,
   curl,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -48,9 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ENABLE_STATIC_LIB" stdenv.hostPlatform.isStatic)
   ];
 
-  doCheck = true;
-
   passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
     inherit curl;
   };
 

--- a/pkgs/ngtcp2/gnutls.nix
+++ b/pkgs/ngtcp2/gnutls.nix
@@ -9,16 +9,17 @@
   ncurses,
   knot-dns,
   curlWithGnuTls,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
   version = "1.18.0";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = "ngtcp2";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-sywzNSyr237U1codaEHtHvz7nqYDiJwjVpr4hpLHE60=";
   };
 
@@ -36,10 +37,10 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-gnutls=yes" ];
   enableParallelBuilding = true;
 
-  doCheck = true;
   nativeCheckInputs = [ cunit ] ++ lib.optional stdenv.hostPlatform.isDarwin ncurses;
 
-  passthru.tests = knot-dns.passthru.tests // {
+  passthru.tests = (knot-dns.passthru.tests or { }) // {
+    unittests = runUnitTests finalAttrs.finalPackage;
     inherit curlWithGnuTls;
   };
 
@@ -49,7 +50,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };
-}
+})
 
 /*
   Why split from ./default.nix?

--- a/pkgs/npth/default.nix
+++ b/pkgs/npth/default.nix
@@ -4,23 +4,23 @@
   fetchurl,
   autoreconfHook,
   pkgsCross,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "npth";
   version = "1.8";
 
   src = fetchurl {
-    url = "mirror://gnupg/npth/npth-${version}.tar.bz2";
+    url = "mirror://gnupg/npth/npth-${finalAttrs.version}.tar.bz2";
     hash = "sha256-i9JLTyOjBl1uWybpirqc54PqT9eBBpwbNdFJaU6Qyj4=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  doCheck = true;
-
   passthru.tests = {
     musl = pkgsCross.musl64.npth;
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
@@ -38,4 +38,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl3;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/openblas/default.nix
+++ b/pkgs/openblas/default.nix
@@ -29,6 +29,7 @@
   enableAVX512 ? false,
   enableStatic ? stdenv.hostPlatform.isStatic,
   enableShared ? !stdenv.hostPlatform.isStatic,
+  runUnitTests,
 
   # for passthru.tests
   ceres-solver ? null,
@@ -179,7 +180,7 @@ let
   shlibExt = stdenv.hostPlatform.extensions.sharedLibrary;
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openblas";
   version = "0.3.30";
 
@@ -191,7 +192,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "OpenMathLib";
     repo = "OpenBLAS";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-foP2OXUL6ttgYvCxLsxUiVdkPoTvGiHomdNudbSUmSE=";
   };
 
@@ -290,9 +291,8 @@ stdenv.mkDerivation rec {
   );
 
   # The default "all" target unconditionally builds the "tests" target.
-  buildFlags = lib.optionals (!doCheck) [ "shared" ];
+  buildFlags = lib.optionals (!finalAttrs.finalPackage.doCheck) [ "shared" ];
 
-  doCheck = true;
   checkTarget = "tests";
 
   postInstall = ''
@@ -301,7 +301,7 @@ stdenv.mkDerivation rec {
         for alias in blas cblas lapack; do
           cat <<EOF > $out/lib/pkgconfig/$alias.pc
     Name: $alias
-    Version: ${version}
+    Version: ${finalAttrs.version}
     Description: $alias provided by the OpenBLAS package.
     Cflags: -I$dev/include
     Libs: -L$out/lib -lopenblas
@@ -340,6 +340,7 @@ stdenv.mkDerivation rec {
       octave
       opencv
       ;
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {
@@ -348,4 +349,4 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/OpenMathLib/OpenBLAS";
     platforms = lib.attrNames configs;
   };
-}
+})

--- a/pkgs/pkg-config-unwrapped/default.nix
+++ b/pkgs/pkg-config-unwrapped/default.nix
@@ -4,14 +4,15 @@
   fetchurl,
   libiconv,
   vanilla ? false,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pkg-config";
   version = "0.29.2";
 
   src = fetchurl {
-    url = "https://pkg-config.freedesktop.org/releases/${pname}-${version}.tar.gz";
+    url = "https://pkg-config.freedesktop.org/releases/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "14fmwzki1rlz8bs2p810lk6jqdxsk966d8drgsjmi54cd00rrikg";
   };
 
@@ -73,9 +74,10 @@ stdenv.mkDerivation rec {
   );
 
   enableParallelBuilding = true;
-  doCheck = true;
 
   postInstall = ''rm -f "$out"/bin/*-pkg-config''; # clean the duplicate file
+
+  passthru.tests.unittests = runUnitTests finalAttrs.finalPackage;
 
   meta = {
     description = "Tool that allows packages to find out information about other packages";
@@ -84,4 +86,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     mainProgram = "pkg-config";
   };
-}
+})

--- a/pkgs/re2c/default.nix
+++ b/pkgs/re2c/default.nix
@@ -5,6 +5,7 @@
   autoreconfHook,
   nix-update-script,
   python3,
+  runUnitTests,
 
   # for passthru.tests
   ninja,
@@ -12,14 +13,14 @@
   spamassassin,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "re2c";
   version = "4.3";
 
   src = fetchFromGitHub {
     owner = "skvadrik";
     repo = "re2c";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-zPOENMfXXgTwds1t+Lrmz9+GTHJf2yRpQsGT7nLRvcg=";
   };
 
@@ -28,7 +29,6 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  doCheck = true;
   enableParallelBuilding = true;
 
   preCheck = ''
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
     };
     tests = {
       inherit ninja php spamassassin;
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
   };
 
@@ -54,4 +55,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.publicDomain;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/rhash/default.nix
+++ b/pkgs/rhash/default.nix
@@ -5,16 +5,17 @@
   which,
   enableStatic ? stdenv.hostPlatform.isStatic,
   gettext,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.4.4";
   pname = "rhash";
 
   src = fetchFromGitHub {
     owner = "rhash";
     repo = "RHash";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-3CW41ULdXoID4cOgrcG2j85tgIJ/sz5hU7A83qpuxf4=";
   };
 
@@ -38,8 +39,6 @@ stdenv.mkDerivation rec {
     (lib.enableFeature enableStatic "lib-static")
   ];
 
-  doCheck = true;
-
   checkTarget = "test-full";
 
   installTargets = [
@@ -50,10 +49,14 @@ stdenv.mkDerivation rec {
     "install-lib-so-link"
   ];
 
+  passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
+
   meta = {
     homepage = "https://rhash.sourceforge.net/";
     description = "Console utility and library for computing and verifying hash sums of files";
     license = lib.licenses.bsd0;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/rsync/default.nix
+++ b/pkgs/rsync/default.nix
@@ -19,15 +19,16 @@
   enableZstd ? true,
   zstd,
   nixosTests,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rsync";
   version = "3.4.1";
 
   src = fetchurl {
     # signed with key 9FEF 112D CE19 A0DC 7E88  2CB8 1BB2 4997 A853 5F6F
-    url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
+    url = "mirror://samba/rsync/src/rsync-${finalAttrs.version}.tar.gz";
     hash = "sha256-KSS8s6Hti1UfwQH3QLnw/gogKxFQJ2R89phQ1l/YjFI=";
   };
 
@@ -78,9 +79,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.tests = { inherit (nixosTests) rsyncd; };
-
-  doCheck = true;
+  passthru.tests = {
+    inherit (nixosTests) rsyncd;
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   __darwinAllowLocalNetworking = true;
 
@@ -92,8 +94,8 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     identifiers.cpeParts = {
       vendor = "samba";
-      inherit version;
+      version = finalAttrs.version;
       update = "-";
     };
   };
-}
+})

--- a/pkgs/runit/default.nix
+++ b/pkgs/runit/default.nix
@@ -5,14 +5,15 @@
 
   # Build runit-init as a static binary
   static ? false,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "runit";
   version = "2.2.0";
 
   src = fetchurl {
-    url = "http://smarden.org/runit/${pname}-${version}.tar.gz";
+    url = "http://smarden.org/runit/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-le9NKGi5eMcXn+R5AeXFeOEc8nPSkr1iCL06fMsCkpA=";
   };
 
@@ -25,9 +26,7 @@ stdenv.mkDerivation rec {
     "man"
   ];
 
-  sourceRoot = "admin/${pname}-${version}";
-
-  doCheck = true;
+  sourceRoot = "admin/${finalAttrs.pname}-${finalAttrs.version}";
 
   buildInputs = lib.optionals static [
     stdenv.cc.libc
@@ -60,6 +59,10 @@ stdenv.mkDerivation rec {
     cp -r ../man $man/share/man/man8
   '';
 
+  passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
+
   meta = {
     description = "UNIX init scheme with service supervision";
     license = lib.licenses.bsd3;
@@ -67,4 +70,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/rust-bindgen/unwrapped.nix
+++ b/pkgs/rust-bindgen/unwrapped.nix
@@ -4,18 +4,19 @@
   rustPlatform,
   clang,
   rustfmt,
+  runUnitTests,
 }:
 let
   # bindgen hardcodes rustfmt outputs that use nightly features
   rustfmt-nightly = rustfmt.override { asNightly = true; };
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rust-bindgen-unwrapped";
   version = "0.72.1";
 
   src = fetchCrate {
     pname = "bindgen-cli";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-rhdQZcnlqVSUqvFDg0Scs1+DHGcKyazeS5H9HH7u8Fk=";
   };
 
@@ -28,10 +29,9 @@ rustPlatform.buildRustPackage rec {
   # Disable the "runtime" feature, so libclang is linked.
   buildNoDefaultFeatures = true;
   buildFeatures = [ "logging" ];
-  checkNoDefaultFeatures = buildNoDefaultFeatures;
-  checkFeatures = buildFeatures;
+  checkNoDefaultFeatures = finalAttrs.buildNoDefaultFeatures;
+  checkFeatures = finalAttrs.buildFeatures;
 
-  doCheck = true;
   nativeCheckInputs = [ clang ];
 
   RUSTFMT = "${rustfmt-nightly}/bin/rustfmt";
@@ -41,7 +41,10 @@ rustPlatform.buildRustPackage rec {
     patchShebangs .
   '';
 
-  passthru = { inherit clang; };
+  passthru = {
+    inherit clang;
+    tests.unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Automatically generates Rust FFI bindings to C (and some C++) libraries";
@@ -54,4 +57,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "bindgen";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/sourceHighlight/default.nix
+++ b/pkgs/sourceHighlight/default.nix
@@ -6,9 +6,10 @@
   boost,
   updateAutotoolsGnuConfigScriptsHook,
   llvmPackages,
+  runUnitTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "source-highlight";
   version = "3.1.9";
 
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "mirror://gnu/src-highlite/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/src-highlite/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "148w47k3zswbxvhg83z38ifi85f9dqcpg7icvvw1cm6bg21x4zrs";
   };
 
@@ -73,12 +74,14 @@ stdenv.mkDerivation rec {
     "--with-bash-completion=${placeholder "out"}/share/bash-completion/completions"
   ];
 
-  doCheck = true;
-
   enableParallelBuilding = true;
   # Upstream uses the same intermediate files in multiple tests, running
   # them in parallel by make will eventually break one or more tests.
   enableParallelChecking = false;
+
+  passthru.tests = {
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Source code renderer with syntax highlighting";
@@ -90,7 +93,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
   };
-}
+})
 // lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
   # Force linking to "libgcc" so tests pass
   NIX_CFLAGS_COMPILE = "-lgcc";

--- a/pkgs/spdlog/default.nix
+++ b/pkgs/spdlog/default.nix
@@ -7,6 +7,7 @@
   fmt,
   catch2_3,
   staticBuild ? stdenv.hostPlatform.isStatic,
+  runUnitTests,
 
   # passthru
   bear,
@@ -67,10 +68,9 @@ stdenv.mkDerivation (finalAttrs: {
         '#define SPDLOG_FMT_EXTERNAL'
   '';
 
-  doCheck = true;
-
   passthru = {
     tests = {
+      unittests = runUnitTests finalAttrs.finalPackage;
       inherit bear tiledb;
     };
     updateScript = nix-update-script { };

--- a/pkgs/tzdata/default.nix
+++ b/pkgs/tzdata/default.nix
@@ -4,6 +4,7 @@
   fetchurl,
   buildPackages,
   postgresql,
+  runUnitTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -67,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
   checkTarget = "check";
 
   installFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
@@ -92,7 +92,10 @@ stdenv.mkDerivation (finalAttrs: {
   # PostgreSQL is sensitive to tzdata updates, because the test-suite often breaks.
   # Upstream provides patches very quickly, we just need to apply them until the next
   # minor releases.
-  passthru.tests = postgresql;
+  passthru.tests = {
+    inherit postgresql;
+    unittests = runUnitTests finalAttrs.finalPackage;
+  };
 
   meta = {
     homepage = "http://www.iana.org/time-zones";

--- a/pkgs/unbound/default.nix
+++ b/pkgs/unbound/default.nix
@@ -52,6 +52,7 @@
   nix-update-script,
   # for passthru.tests
   gnutls,
+  runUnitTests,
 }:
 
 assert withDoH -> libnghttp2 != null;
@@ -160,8 +161,6 @@ stdenv.mkDerivation (finalAttrs: {
       sed -E '/CONFCMDLINE/ s;${storeDir}/[a-z0-9]{32}-;${storeDir}/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-;g' -i config.h
     '';
 
-  doCheck = true;
-
   postPatch = lib.optionalString withPythonModule ''
     substituteInPlace Makefile.in \
       --replace "\$(DESTDIR)\$(PYTHON_SITE_PKG)" "$out/${python.sitePackages}"
@@ -212,6 +211,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     };
     tests = {
+      unittests = runUnitTests finalAttrs.finalPackage;
       inherit gnutls;
       nixos-test = nixosTests.unbound;
       nixos-test-exporter = nixosTests.prometheus-exporters.unbound;

--- a/pkgs/xz/default.nix
+++ b/pkgs/xz/default.nix
@@ -6,6 +6,7 @@
   enableStatic ? stdenv.hostPlatform.isStatic,
   writeScript,
   testers,
+  runUnitTests,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -36,7 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = lib.optional enableStatic "--disable-shared";
 
   enableParallelBuilding = true;
-  doCheck = true;
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isOpenBSD [
     autoreconfHook
@@ -72,8 +72,11 @@ stdenv.mkDerivation (finalAttrs: {
           head -n1)"
       update-source-version ${finalAttrs.pname} "$new_version"
     '';
-    tests.pkg-config = testers.hasPkgConfigModules {
-      package = finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+      unittests = runUnitTests finalAttrs.finalPackage;
     };
   };
 

--- a/pkgs/zlib/default.nix
+++ b/pkgs/zlib/default.nix
@@ -12,6 +12,7 @@
   splitStaticOutput ? shared && static,
   testers,
   minizip,
+  runUnitTests,
 }:
 
 # Without either the build will actually still succeed because the build
@@ -133,7 +134,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
-  doCheck = true;
 
   makeFlags = [
     "PREFIX=${stdenv.cc.targetPrefix}"
@@ -153,6 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config-install = testers.pkg-config.testInstall finalAttrs.finalPackage { };
     # uses `zlib` derivation:
     inherit minizip;
+    unittests = runUnitTests finalAttrs.finalPackage;
   };
 
   meta = {

--- a/python/mk-python-derivation.nix
+++ b/python/mk-python-derivation.nix
@@ -211,7 +211,7 @@ lib.extendMkDerivation {
 
       meta ? { },
 
-      doCheck ? true,
+      doCheck ? false,
 
       ...
     }@attrs:

--- a/stdenv/generic/make-derivation.nix
+++ b/stdenv/generic/make-derivation.nix
@@ -334,13 +334,10 @@ let
       configureFlags ? [ ],
       configurePlatforms ? defaultConfigurePlatforms,
 
-      # TODO(@Ericson2314): Make unconditional / resolve #33599
-      # Check phase
-      doCheck ? config.doCheckByDefault or false,
-
-      # TODO(@Ericson2314): Make unconditional / resolve #33599
-      # InstallCheck phase
-      doInstallCheck ? config.doCheckByDefault or false,
+      # Ekapkgs: unittests should be move to passthru unless very quick
+      # and don't intoduce more dependencies
+      doCheck ? false,
+      doInstallCheck ? false,
 
       # TODO(@Ericson2314): Make always true and remove / resolve #178468
       strictDeps ? defaultStrictDeps,


### PR DESCRIPTION
This defaults `doCheck` to false and moves it to passthru tests. The main goal is to avoid having to build test dependencies as part of the vanilla build, also it avoids having to have the test suite impacting rebuild times which we are trying to optimize for mass rebuilding.