### PR TITLE
Python testing

### DIFF
--- a/docs/major-differences-nixpkgs.md
+++ b/docs/major-differences-nixpkgs.md
@@ -14,3 +14,19 @@ changes differ significantly from whath one would expct with Nixpkgs.
 
 - setupHooks for build managers are now explicit and opt-in.
   - E.g. `meson.configurePhaseHook` now needs to be specified.
+- `doCheck` now defaults to `false` across the package set.
+  - Test suites are not executed as part of the main build by default.
+  - This keeps the critical build path lean and avoids rebuilding the world
+    when only a test-related input changes.
+  - To run a package's tests, override with `doCheck = true` or evaluate the
+    dedicated test derivation (e.g. `pkg.passthru.tests.*`).
+- `buildPythonPackage` exposes a `testDir` attribute for deferring test
+  execution into a separate derivation.
+  - When set, `testDir` should point to the directory (relative to the source
+    root) containing the package's test suite.
+  - An additional `test-src` output is produced containing just the test
+    sources, and a `passthru.tests.python` derivation is auto-generated that
+    runs the test suite against the installed package using the configured
+    `nativeCheckInputs` / `checkInputs`.
+  - This decouples test execution from the main build, allowing test failures
+    or test-only dependency churn to avoid invalidating downstream consumers.

--- a/python/hooks/default.nix
+++ b/python/hooks/default.nix
@@ -363,6 +363,13 @@ in
     } ./python-output-dist-hook.sh
   ) { };
 
+  pythonOutputTestSrcHook = callPackage (
+    { makePythonHook }:
+    makePythonHook {
+      name = "python-output-test-src-hook";
+    } ./python-output-test-src-hook.sh
+  ) { };
+
   pythonRecompileBytecodeHook = callPackage (
     { makePythonHook }:
     makePythonHook {

--- a/python/hooks/python-output-test-src-hook.sh
+++ b/python/hooks/python-output-test-src-hook.sh
@@ -1,0 +1,22 @@
+# Setup hook for storing test sources in a separate output
+# shellcheck shell=bash
+
+echo "Sourcing python-output-test-src-hook.sh"
+
+pythonOutputTestSrcPhase() {
+    echo "Executing pythonOutputTestSrcPhase"
+    if [[ -n "${testDir:-}" && -d "$testDir" ]]; then
+        # shellcheck disable=SC2154
+        mkdir -p "$test_src"
+        cp -R "$testDir" "$test_src/"
+    else
+        cat >&2 <<EOF
+testDir='${testDir:-}' does not exist in the source tree.
+Ensure the testDir attribute points to a valid directory relative to the source root.
+EOF
+        return 1
+    fi
+    echo "Finished executing pythonOutputTestSrcPhase"
+}
+
+appendToVar preFixupPhases pythonOutputTestSrcPhase

--- a/python/mk-python-derivation.nix
+++ b/python/mk-python-derivation.nix
@@ -19,6 +19,7 @@
   pythonImportsCheckHook,
   pythonNamespacesHook,
   pythonOutputDistHook,
+  pythonOutputTestSrcHook,
   pythonRelaxDepsHook,
   pythonRemoveBinBytecodeHook,
   pythonRemoveTestsDirHook,
@@ -113,10 +114,42 @@ let
     "build-system"
   ];
 
+  # Python-specific attrs that should be visible to the user's `finalAttrs`
+  # fixed-point view but stripped from the underlying mkDerivation call so they
+  # are not forwarded to the `derivation` builtin (which cannot coerce attrsets
+  # like `optional-dependencies` to strings).
+  pythonOnlyAttrNames = [
+    "dependencies"
+    "optional-dependencies"
+    "build-system"
+  ];
+
+  # Wrap `stdenv.mkDerivation` so that the user's function sees a `finalAttrs`
+  # value containing Python-specific attributes (e.g. `optional-dependencies`),
+  # while the underlying `mkDerivation` receives a sanitised attrset.
+  pythonMkDerivation =
+    fn:
+    stdenv.mkDerivation (
+      drvFinalAttrs:
+      let
+        # Re-expose the Python-specific attrs that the inner `mkDerivation`
+        # doesn't track. These reference the user's own returned attrs, so the
+        # fixed-point still terminates as long as the user doesn't define them
+        # in terms of `finalAttrs.<pythonOnlyAttr>` itself.
+        userFinalAttrs = drvFinalAttrs // {
+          dependencies = userAttrs.dependencies or [ ];
+          optional-dependencies = userAttrs.optional-dependencies or { };
+          build-system = userAttrs.build-system or [ ];
+        };
+        userAttrs = fn userFinalAttrs;
+      in
+      removeAttrs userAttrs pythonOnlyAttrNames
+    );
+
 in
 
 lib.extendMkDerivation {
-  constructDrv = stdenv.mkDerivation;
+  constructDrv = pythonMkDerivation;
 
   excludeDrvArgNames = [
     "disabled"
@@ -166,6 +199,21 @@ lib.extendMkDerivation {
       strictDeps ? true,
 
       outputs ? [ "out" ],
+
+      # Files and/or directories (relative to the source root) to bundle into
+      # the `test_src` output. When non-empty, a "test_src" output is created
+      # and `passthru.tests.python` is auto-generated to run the package's
+      # test suite against the installed package without rebuilding.
+      #
+      # Typical usage is `testPaths = [ "tests" ];`. Packages whose suites
+      # reference sibling files (helper modules, fixture data, README files
+      # used by doctests, etc.) should list those alongside the test
+      # directory, e.g. `testPaths = [ "tests" "smartypants" "README.rst" ];`.
+      #
+      # The list is forwarded to the `pythonOutputTestSrcHook` as a
+      # whitespace-separated environment variable; entries must therefore
+      # not contain whitespace.
+      testPaths ? [ ],
 
       # used to disable derivation, useful for specific python versions
       disabled ? false,
@@ -242,6 +290,8 @@ lib.extendMkDerivation {
           throw "${name} does not configure a `format`. To build with setuptools as before, set `pyproject = true` and `build-system = [ setuptools ]`.`";
 
       withDistOutput = withDistOutput' format';
+
+      withTestSrcOutput = testPaths != [ ];
 
       validatePythonMatches =
         let
@@ -384,6 +434,9 @@ lib.extendMkDerivation {
       ++ optionals withDistOutput [
         pythonOutputDistHook
       ]
+      ++ optionals withTestSrcOutput [
+        pythonOutputTestSrcHook
+      ]
       ++ nativeBuildInputs
       ++ getFinalPassthru "build-system";
 
@@ -406,7 +459,7 @@ lib.extendMkDerivation {
 
       # Python packages don't have a checkPhase, only an installCheckPhase
       doCheck = false;
-      doInstallCheck = attrs.doCheck or true;
+      doInstallCheck = doCheck;
       nativeInstallCheckInputs = nativeCheckInputs ++ attrs.nativeInstallCheckInputs or [ ];
       installCheckInputs = checkInputs ++ attrs.installCheckInputs or [ ];
 
@@ -423,21 +476,89 @@ lib.extendMkDerivation {
         python.pythonOnBuildForHost
       ];
 
-      outputs = outputs ++ optional withDistOutput "dist";
-
-      passthru = {
-        inherit
-          disabled
-          pyproject
-          build-system
-          dependencies
-          optional-dependencies
-          ;
-      }
-      // {
-        updateScript = nix-update-script { };
-      }
-      // attrs.passthru or { };
+      outputs = outputs ++ optional withDistOutput "dist" ++ optional withTestSrcOutput "test_src";
+    }
+    // {
+      # Re-expose Python-specific attrs at the top-level of the returned
+      # attrset so that they're visible in the user's `finalAttrs` fixed-point
+      # view (see `pythonMkDerivation`). These are removed before being passed
+      # to `stdenv.mkDerivation`, so they never reach the `derivation` builtin.
+      inherit dependencies optional-dependencies build-system;
+    }
+    // optionalAttrs withTestSrcOutput {
+      inherit testPaths;
+    }
+    // {
+      passthru =
+        let
+          userPassthru = attrs.passthru or { };
+          # Forward test-related hooks from the parent derivation so that
+          # patchShebangs, environment setup, fixture preparation, etc. all
+          # apply in the auto-generated test derivation as well.
+          forwardedTestHookNames = [
+            "preCheck"
+            "postCheck"
+            "preInstallCheck"
+            "postInstallCheck"
+            "disabledTests"
+            "disabledTestPaths"
+            "enabledTestPaths"
+            "pytestFlags"
+            "pytestFlagsArray"
+            "unittestFlagsArray"
+            "PYTEST_DISABLE_PLUGIN_AUTOLOAD"
+          ];
+          forwardedTestHooks = lib.filterAttrs (n: _: attrs ? ${n}) (
+            lib.genAttrs forwardedTestHookNames (n: attrs.${n} or null)
+          );
+          autoTests = optionalAttrs withTestSrcOutput {
+            python = stdenv.mkDerivation (
+              {
+                name = "${name}-tests";
+                src = finalAttrs.finalPackage.test_src;
+                dontConfigure = true;
+                dontBuild = true;
+                # We still produce an empty `$out` because some preDist hooks
+                # (e.g. pytest's `pytestcachePhase`) expect it to exist.
+                installPhase = "mkdir -p $out";
+                # Python check hooks (pytestCheckHook, unittestCheckHook, ...)
+                # append themselves to preDistPhases, which runs after the
+                # installCheckPhase. We enable both doCheck and doInstallCheck
+                # so that any user-provided checkPhase / installCheckPhase
+                # forwarded below also executes.
+                doCheck = true;
+                doInstallCheck = true;
+                nativeBuildInputs = [
+                  python
+                  finalAttrs.finalPackage
+                ]
+                ++ nativeCheckInputs;
+                buildInputs = checkInputs;
+              }
+              // forwardedTestHooks
+              // optionalAttrs (attrs ? checkPhase) {
+                # Mirror the parent's handling: a user-supplied checkPhase is
+                # really an installCheckPhase in Python land.
+                installCheckPhase = attrs.checkPhase;
+              }
+              // optionalAttrs (attrs ? installCheckPhase) {
+                inherit (attrs) installCheckPhase;
+              }
+            );
+          };
+        in
+        {
+          inherit
+            disabled
+            pyproject
+            build-system
+            dependencies
+            optional-dependencies
+            ;
+          updateScript = nix-update-script { };
+          tests = autoTests // (userPassthru.tests or { });
+        }
+        // removeAttrs userPassthru [ "tests" ];
 
       meta = {
         # default to python's platforms

--- a/python/pkgs/aiohttp/default.nix
+++ b/python/pkgs/aiohttp/default.nix
@@ -49,7 +49,7 @@
   zlib-ng,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aiohttp";
   version = "3.13.2";
   pyproject = true;
@@ -57,7 +57,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = "aiohttp";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-LqYGrrWgSZazk0hjQvTFwqtU/PtMEaPi+m1Ya8Ds+pU=";
   };
 
@@ -99,7 +99,7 @@ buildPythonPackage rec {
   ++ lib.optionals (pythonOlder "3.11") [
     async-timeout
   ]
-  ++ optional-dependencies.speedups;
+  ++ finalAttrs.optional-dependencies.speedups;
 
   optional-dependencies.speedups = [
     aiodns
@@ -164,11 +164,13 @@ buildPythonPackage rec {
     export TMPDIR="/tmp"
   '';
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://docs.aiohttp.org/en/${src.tag}/changes.html";
+    changelog = "https://docs.aiohttp.org/en/${finalAttrs.src.tag}/changes.html";
     description = "Asynchronous HTTP Client/Server for Python and asyncio";
     license = lib.licenses.asl20;
     homepage = "https://github.com/aio-libs/aiohttp";
 
   };
-}
+})

--- a/python/pkgs/aiohttp/default.nix
+++ b/python/pkgs/aiohttp/default.nix
@@ -150,6 +150,8 @@ buildPythonPackage (finalAttrs: {
     "test_close"
   ];
 
+  testPaths = [ "tests" ];
+
   __darwinAllowLocalNetworking = true;
 
   preCheck = ''
@@ -163,8 +165,6 @@ buildPythonPackage (finalAttrs: {
     # Work around "OSError: AF_UNIX path too long"
     export TMPDIR="/tmp"
   '';
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://docs.aiohttp.org/en/${finalAttrs.src.tag}/changes.html";

--- a/python/pkgs/babel/default.nix
+++ b/python/pkgs/babel/default.nix
@@ -39,6 +39,13 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optionals isPyPy [ tzdata ];
 
+  # Some tests read `babel/locale-data/*.dat` and `babel/global.dat` as
+  # plain files relative to the source root.
+  testPaths = [
+    "tests"
+    "babel"
+  ];
+
   disabledTests = [
     # fails on days switching from and to daylight saving time in EST
     # https://github.com/python-babel/babel/issues/988
@@ -46,8 +53,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "babel" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Collection of internationalizing tools";

--- a/python/pkgs/babel/default.nix
+++ b/python/pkgs/babel/default.nix
@@ -16,7 +16,7 @@
   tzdata,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "babel";
   version = "2.17.0";
   pyproject = true;
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-DFTP+xn2kM3MUqO1C8v3HgeoCNHIDVSfJFm50s8K+50=";
   };
 
@@ -47,12 +47,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "babel" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Collection of internationalizing tools";
     homepage = "https://babel.pocoo.org/";
-    changelog = "https://github.com/python-babel/babel/releases/tag/v${version}";
+    changelog = "https://github.com/python-babel/babel/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
 
     mainProgram = "pybabel";
   };
-}
+})

--- a/python/pkgs/bcrypt/3.nix
+++ b/python/pkgs/bcrypt/3.nix
@@ -29,9 +29,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "bcrypt" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "bcrypt" ];
 
   meta = {
     description = "Modern password hashing for your software and your servers";

--- a/python/pkgs/bcrypt/3.nix
+++ b/python/pkgs/bcrypt/3.nix
@@ -8,13 +8,13 @@
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "bcrypt";
   version = "3.2.2";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-QzxBDCF3BXcF2iqfLNAd0VdJOyp6wUyFk6FrPatra/s=";
   };
 
@@ -31,10 +31,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "bcrypt" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Modern password hashing for your software and your servers";
     homepage = "https://github.com/pyca/bcrypt/";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/betamax/default.nix
+++ b/python/pkgs/betamax/default.nix
@@ -7,13 +7,13 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "betamax";
   version = "0.9.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-gjFuFnm8aHnjyDMY0Ba1S3ySJf8IxEYt5IE+IgONX5Q=";
   };
 
@@ -35,11 +35,13 @@ buildPythonPackage rec {
     "tests/regression/test_requests_2_11_body_matcher.py"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "VCR imitation for requests";
     homepage = "https://betamax.readthedocs.org/";
-    changelog = "https://github.com/betamaxpy/betamax/blob/${version}/HISTORY.rst";
+    changelog = "https://github.com/betamaxpy/betamax/blob/${finalAttrs.version}/HISTORY.rst";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/betamax/default.nix
+++ b/python/pkgs/betamax/default.nix
@@ -23,6 +23,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   pythonImportsCheck = [ "betamax" ];
 
   disabledTestPaths = [
@@ -34,8 +36,6 @@ buildPythonPackage (finalAttrs: {
     "tests/regression/test_gzip_compression.py"
     "tests/regression/test_requests_2_11_body_matcher.py"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "VCR imitation for requests";

--- a/python/pkgs/black/default.nix
+++ b/python/pkgs/black/default.nix
@@ -92,6 +92,8 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.concatAttrValues finalAttrs.optional-dependencies;
 
+  testPaths = [ "tests" ];
+
   pytestFlags = [
     "-Wignore::DeprecationWarning"
   ];
@@ -124,8 +126,6 @@ buildPythonPackage (finalAttrs: {
   ];
   # multiple tests exceed max open files on hydra builders
   doCheck = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Uncompromising Python code formatter";

--- a/python/pkgs/black/default.nix
+++ b/python/pkgs/black/default.nix
@@ -24,7 +24,7 @@
   uvloop,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "black";
   version = "25.1.0";
   format = "pyproject";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-M0ltXNEiKtczkTUrSujaFSU8Xeibk6gLPiyNmhnsJmY=";
   };
 
@@ -90,7 +90,7 @@ buildPythonPackage rec {
     pytestCheckHook
     parameterized
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.optional-dependencies;
 
   pytestFlags = [
     "-Wignore::DeprecationWarning"
@@ -125,12 +125,14 @@ buildPythonPackage rec {
   # multiple tests exceed max open files on hydra builders
   doCheck = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Uncompromising Python code formatter";
     homepage = "https://github.com/psf/black";
-    changelog = "https://github.com/psf/black/blob/${version}/CHANGES.md";
+    changelog = "https://github.com/psf/black/blob/${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.mit;
     mainProgram = "black";
 
   };
-}
+})

--- a/python/pkgs/buildcatrust/default.nix
+++ b/python/pkgs/buildcatrust/default.nix
@@ -6,13 +6,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "buildcatrust";
   version = "0.3.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Ac10CZdihFBmr5LE6xFKx4+zr2n5nyR23px6N4vN05M=";
   };
 
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     "buildcatrust.cli"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Build SSL/TLS trust stores";
     mainProgram = "buildcatrust";
@@ -37,4 +39,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/buildcatrust/default.nix
+++ b/python/pkgs/buildcatrust/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage (finalAttrs: {
 
   # nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "buildcatrust/tests" ];
+
   disabledTestPaths = [
     # Non-hermetic, needs internet access (e.g. attempts to retrieve NSS store).
     "buildcatrust/tests/test_nonhermetic.py"
@@ -29,8 +31,6 @@ buildPythonPackage (finalAttrs: {
     "buildcatrust"
     "buildcatrust.cli"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Build SSL/TLS trust stores";

--- a/python/pkgs/certifi/default.nix
+++ b/python/pkgs/certifi/default.nix
@@ -8,7 +8,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "certifi";
   version = "2025.07.14";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "certifi";
     repo = "python-certifi";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-TSqBca42i7i59ERTrnPN0fLdLWToYMCq5cfFFsgZm5U=";
   };
 
@@ -44,10 +44,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "certifi" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     homepage = "https://github.com/certifi/python-certifi";
     description = "Python package for providing Mozilla's CA Bundle";
     license = lib.licenses.isc;
 
   };
-}
+})

--- a/python/pkgs/certifi/default.nix
+++ b/python/pkgs/certifi/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "certifi" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  testPaths = [ "certifi/tests" ];
 
   meta = {
     homepage = "https://github.com/certifi/python-certifi";

--- a/python/pkgs/cffi/default.nix
+++ b/python/pkgs/cffi/default.nix
@@ -10,7 +10,7 @@
   stdenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cffi";
   version = "2.0.0";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "python-cffi";
     repo = "cffi";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7Mzz3KmmmE2xQru1GA4aY0DZqn6vxykWiExQvnA1bjM=";
   };
 
@@ -35,11 +35,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/python-cffi/cffi/releases/tag/v${version}";
+    changelog = "https://github.com/python-cffi/cffi/releases/tag/v${finalAttrs.version}";
     description = "Foreign Function Interface for Python calling C code";
     downloadPage = "https://github.com/python-cffi/cffi";
     homepage = "https://cffi.readthedocs.org/";
     license = lib.licenses.mit0;
   };
-}
+})

--- a/python/pkgs/cffi/default.nix
+++ b/python/pkgs/cffi/default.nix
@@ -35,7 +35,11 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  # `testing/cffi1/test_parse_c_type.py` reads `src/cffi/parse_c_type.h`.
+  testPaths = [
+    "testing"
+    "src"
+  ];
 
   meta = {
     changelog = "https://github.com/python-cffi/cffi/releases/tag/v${finalAttrs.version}";

--- a/python/pkgs/chameleon/default.nix
+++ b/python/pkgs/chameleon/default.nix
@@ -26,9 +26,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "chameleon" ];
+  testPaths = [ "src/chameleon/tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "chameleon" ];
 
   meta = {
     changelog = "https://github.com/malthe/chameleon/blob/${finalAttrs.src.tag}/CHANGES.rst";

--- a/python/pkgs/chameleon/default.nix
+++ b/python/pkgs/chameleon/default.nix
@@ -8,7 +8,7 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "chameleon";
   version = "4.6.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "malthe";
     repo = "chameleon";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-zCEM5yl8Y11FbexD7veS9bFJgm30L6fsTde59m2t1ec=";
   };
 
@@ -28,12 +28,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "chameleon" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/malthe/chameleon/blob/${src.tag}/CHANGES.rst";
+    changelog = "https://github.com/malthe/chameleon/blob/${finalAttrs.src.tag}/CHANGES.rst";
     description = "Fast HTML/XML Template Compiler";
     downloadPage = "https://github.com/malthe/chameleon";
     homepage = "https://chameleon.readthedocs.io";
     license = lib.licenses.bsd0;
 
   };
-}
+})

--- a/python/pkgs/chardet/default.nix
+++ b/python/pkgs/chardet/default.nix
@@ -26,14 +26,20 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  # chardet's test runner is a single `test.py` at the source root, with
+  # `setup.cfg` configuring pytest to use `python_files = test.py` and
+  # `tests/` containing the sample data files it loads.
+  testPaths = [
+    "tests"
+    "test.py"
+  ];
+
   disabledTests = [
     # flaky; https://github.com/chardet/chardet/issues/256
     "test_detect_all_and_detect_one_should_agree"
   ];
 
   pythonImportsCheck = [ "chardet" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://github.com/chardet/chardet/releases/tag/${finalAttrs.version}";

--- a/python/pkgs/chardet/default.nix
+++ b/python/pkgs/chardet/default.nix
@@ -8,14 +8,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "chardet";
   version = "5.2.0";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Gztv9HmoxBS8P6LAhSmVaVxKAm3NbQYzst0JLKOcHPc=";
   };
 
@@ -33,12 +33,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "chardet" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/chardet/chardet/releases/tag/${version}";
+    changelog = "https://github.com/chardet/chardet/releases/tag/${finalAttrs.version}";
     description = "Universal encoding detector";
     mainProgram = "chardetect";
     homepage = "https://github.com/chardet/chardet";
     license = lib.licenses.lgpl21Plus;
 
   };
-}
+})

--- a/python/pkgs/cleo/default.nix
+++ b/python/pkgs/cleo/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  testPaths = [ "tests" ];
 
   meta = {
     homepage = "https://github.com/python-poetry/cleo";

--- a/python/pkgs/cleo/default.nix
+++ b/python/pkgs/cleo/default.nix
@@ -9,7 +9,7 @@
   rapidfuzz,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cleo";
   version = "2.2.1";
   format = "pyproject";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = "cleo";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-+OvE09hbF6McdXpXdv5UBdZ0LiSOTL8xyE/+bBNIFNk=";
   };
 
@@ -44,11 +44,13 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     homepage = "https://github.com/python-poetry/cleo";
-    changelog = "https://github.com/python-poetry/cleo/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/python-poetry/cleo/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     description = "Allows you to create beautiful and testable command-line interfaces";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/cryptography/default.nix
+++ b/python/pkgs/cryptography/default.nix
@@ -19,7 +19,7 @@
   rustPlatform,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cryptography";
   version = "46.0.6";
   pyproject = true;
@@ -27,12 +27,12 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pyca";
     repo = "cryptography";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-b6wQnPEf18ViqQVch+Jg1w0Cn372QKxLknD9rL4JjxY=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-5ElDEl7MdcQfu/hy+POSBcvkNCFAMo6La5s6uRhZ/fM=";
   };
 
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-xdist
   ]
-  ++ optional-dependencies.ssh;
+  ++ finalAttrs.optional-dependencies.ssh;
 
   pytestFlags = [ "--disable-pytest-warnings" ];
 
@@ -78,6 +78,7 @@ buildPythonPackage rec {
 
   passthru = {
     vectors = cryptography-vectors;
+    tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
   };
 
   meta = {
@@ -88,7 +89,7 @@ buildPythonPackage rec {
       digests, and key derivation functions.
     '';
     homepage = "https://github.com/pyca/cryptography";
-    changelog = "https://cryptography.io/en/latest/changelog/#v" + lib.replaceString "." "-" version;
+    changelog = "https://cryptography.io/en/latest/changelog/#v" + lib.replaceString "." "-" finalAttrs.version;
     license = with lib.licenses; [
       asl20
       bsd3
@@ -96,4 +97,4 @@ buildPythonPackage rec {
     ];
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/cryptography/default.nix
+++ b/python/pkgs/cryptography/default.nix
@@ -89,7 +89,8 @@ buildPythonPackage (finalAttrs: {
       digests, and key derivation functions.
     '';
     homepage = "https://github.com/pyca/cryptography";
-    changelog = "https://cryptography.io/en/latest/changelog/#v" + lib.replaceString "." "-" finalAttrs.version;
+    changelog =
+      "https://cryptography.io/en/latest/changelog/#v" + lib.replaceString "." "-" finalAttrs.version;
     license = with lib.licenses; [
       asl20
       bsd3

--- a/python/pkgs/dataclasses-json/default.nix
+++ b/python/pkgs/dataclasses-json/default.nix
@@ -46,6 +46,8 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [ "tests" ];
+
   disabledTestPaths = [
     # fails with the following error and avoid dependency on mypy
     # mypy_main(None, text_io, text_io, [__file__], clean_exit=True)
@@ -54,8 +56,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "dataclasses_json" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Simple API for encoding and decoding dataclasses to and from JSON";

--- a/python/pkgs/dataclasses-json/default.nix
+++ b/python/pkgs/dataclasses-json/default.nix
@@ -11,7 +11,7 @@
   typing-inspect,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "dataclasses-json";
   version = "0.6.7";
   pyproject = true;
@@ -21,14 +21,14 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "lidatong";
     repo = "dataclasses-json";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-AH/T6pa/CHtQNox67fqqs/BBnUcmThvbnSHug2p33qM=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail 'documentation =' 'Documentation =' \
-      --replace-fail 'version = "0.0.0"' 'version = "${version}"'
+      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
   '';
 
   build-system = [
@@ -55,11 +55,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "dataclasses_json" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Simple API for encoding and decoding dataclasses to and from JSON";
     homepage = "https://github.com/lidatong/dataclasses-json";
-    changelog = "https://github.com/lidatong/dataclasses-json/releases/tag/v${version}";
+    changelog = "https://github.com/lidatong/dataclasses-json/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/ephemeral-port-reserve/default.nix
+++ b/python/pkgs/ephemeral-port-reserve/default.nix
@@ -6,18 +6,15 @@
   pytestCheckHook,
 }:
 
-let
+buildPythonPackage (finalAttrs: {
   pname = "ephemeral-port-reserve";
   version = "1.1.4";
-in
-buildPythonPackage {
-  inherit pname version;
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "Yelp";
     repo = "ephemeral-port-reserve";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-R6NRpfaT05PO/cTWgCakiGfCuCyucjVOXbAezn5x1cU=";
   };
 
@@ -32,10 +29,12 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "ephemeral_port_reserve" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Find an unused port, reliably";
     mainProgram = "ephemeral-port-reserve";
     homepage = "https://github.com/Yelp/ephemeral-port-reserve/";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/ephemeral-port-reserve/default.nix
+++ b/python/pkgs/ephemeral-port-reserve/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # can't find hostname in our darwin build environment
     "test_fqdn"
@@ -28,8 +30,6 @@ buildPythonPackage (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "ephemeral_port_reserve" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Find an unused port, reliably";

--- a/python/pkgs/exceptiongroup/default.nix
+++ b/python/pkgs/exceptiongroup/default.nix
@@ -29,11 +29,11 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   doCheck = pythonAtLeast "3.11"; # infinite recursion with pytest
 
   pythonImportsCheck = [ "exceptiongroup" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Backport of PEP 654 (exception groups)";

--- a/python/pkgs/exceptiongroup/default.nix
+++ b/python/pkgs/exceptiongroup/default.nix
@@ -9,7 +9,7 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "exceptiongroup";
   version = "1.3.0";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "agronholm";
     repo = "exceptiongroup";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-b3Z1NsYKp0CecUq8kaC/j3xR/ZZHDIw4MhUeadizz88=";
   };
 
@@ -33,11 +33,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "exceptiongroup" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Backport of PEP 654 (exception groups)";
     homepage = "https://github.com/agronholm/exceptiongroup";
-    changelog = "https://github.com/agronholm/exceptiongroup/blob/${version}/CHANGES.rst";
+    changelog = "https://github.com/agronholm/exceptiongroup/blob/${finalAttrs.version}/CHANGES.rst";
     license = with lib.licenses; [ mit ];
 
   };
-}
+})

--- a/python/pkgs/execnet/default.nix
+++ b/python/pkgs/execnet/default.nix
@@ -9,13 +9,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "execnet";
   version = "2.1.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-UYm1LGEhwk/q4ogWarQbMlScfiNIZSc2VAuebn1OcuM=";
   };
 
@@ -56,11 +56,13 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Distributed Python deployment and communication";
     homepage = "https://execnet.readthedocs.io/";
-    changelog = "https://github.com/pytest-dev/execnet/blob/v${version}/CHANGELOG.rst";
+    changelog = "https://github.com/pytest-dev/execnet/blob/v${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/execnet/default.nix
+++ b/python/pkgs/execnet/default.nix
@@ -43,6 +43,8 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [ "testing" ];
+
   disabledTests = [
     # gets stuck
     "test_popen_io"
@@ -55,8 +57,6 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "execnet" ];
 
   __darwinAllowLocalNetworking = true;
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Distributed Python deployment and communication";

--- a/python/pkgs/fastjsonschema/default.nix
+++ b/python/pkgs/fastjsonschema/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "fastjsonschema";
   version = "2.21.1";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "horejsek";
     repo = "python-fastjsonschema";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-H/jmvm5U4RB9KuD5EgCedbc499Fl8L2S9Y5SXy51JP0=";
   };
@@ -44,6 +44,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "fastjsonschema" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "JSON schema validator for Python";
     downloadPage = "https://github.com/horejsek/python-fastjsonschema";
@@ -51,4 +53,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
 
   };
-}
+})

--- a/python/pkgs/fastjsonschema/default.nix
+++ b/python/pkgs/fastjsonschema/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = [
     "benchmark"
     # these tests require network access
@@ -43,8 +45,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "fastjsonschema" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "JSON schema validator for Python";

--- a/python/pkgs/filelock/default.nix
+++ b/python/pkgs/filelock/default.nix
@@ -32,14 +32,14 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [ "tests" ];
+
   pythonImportsCheck = [ "filelock" ];
 
   disabledTestPaths = [
     # Circular dependency with virtualenv
     "tests/test_virtualenv.py"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://github.com/tox-dev/py-filelock/releases/tag/${finalAttrs.version}";

--- a/python/pkgs/filelock/default.nix
+++ b/python/pkgs/filelock/default.nix
@@ -10,13 +10,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "filelock";
   version = "3.20.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-cR6UO07GvkLh1OZpC0jcF1yCKWdGa7McDCk/NDNME/Q=";
   };
 
@@ -39,11 +39,13 @@ buildPythonPackage rec {
     "tests/test_virtualenv.py"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/tox-dev/py-filelock/releases/tag/${version}";
+    changelog = "https://github.com/tox-dev/py-filelock/releases/tag/${finalAttrs.version}";
     description = "Platform independent file lock for Python";
     homepage = "https://github.com/benediktschmitt/py-filelock";
     license = lib.licenses.unlicense;
 
   };
-}
+})

--- a/python/pkgs/flake8/default.nix
+++ b/python/pkgs/flake8/default.nix
@@ -32,13 +32,18 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  # `tests/integration/test_main.py` invokes `bin/gen-pycodestyle-plugin`
+  # relative to the repository root.
+  testPaths = [
+    "tests"
+    "bin"
+  ];
+
   disabledTests = lib.optionals isPyPy [
     # tests fail due to slightly different error position
     "test_tokenization_error_is_a_syntax_error"
     "test_tokenization_error_but_not_syntax_error"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://github.com/PyCQA/flake8/blob/${finalAttrs.src.tag}/docs/source/release-notes/${finalAttrs.version}.rst";

--- a/python/pkgs/flake8/default.nix
+++ b/python/pkgs/flake8/default.nix
@@ -10,7 +10,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flake8";
   version = "7.3.0";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = "flake8";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-dZFIGyjqkd+MRz9NoOEcMuR9ZshFb/h+zO2OJZsQajc=";
   };
 
@@ -38,12 +38,14 @@ buildPythonPackage rec {
     "test_tokenization_error_but_not_syntax_error"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/PyCQA/flake8/blob/${src.tag}/docs/source/release-notes/${version}.rst";
+    changelog = "https://github.com/PyCQA/flake8/blob/${finalAttrs.src.tag}/docs/source/release-notes/${finalAttrs.version}.rst";
     description = "Modular source code checker: pep8, pyflakes and co";
     homepage = "https://github.com/PyCQA/flake8";
     license = lib.licenses.mit;
 
     mainProgram = "flake8";
   };
-}
+})

--- a/python/pkgs/flit/default.nix
+++ b/python/pkgs/flit/default.nix
@@ -51,6 +51,8 @@ buildPythonPackage (finalAttrs: {
     responses
   ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = [
     # needs some ini file.
     "test_invalid_classifier"
@@ -60,8 +62,6 @@ buildPythonPackage (finalAttrs: {
     "test_symlink_data_dir"
     "test_symlink_module_pep621"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://github.com/pypa/flit/blob/${finalAttrs.version}/doc/history.rst";

--- a/python/pkgs/flit/default.nix
+++ b/python/pkgs/flit/default.nix
@@ -23,7 +23,7 @@
 # python-packages.nix. When it will be used to build wheels,
 # care should be taken that there is no mingling of PYTHONPATH.
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flit";
   version = "3.12.0";
   format = "pyproject";
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "flit";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-oWV+KK22+iK99iCOCKCV1OCLq2Ef1bcYRKXT5GHwiL8=";
   };
 
@@ -61,11 +61,13 @@ buildPythonPackage rec {
     "test_symlink_module_pep621"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/pypa/flit/blob/${version}/doc/history.rst";
+    changelog = "https://github.com/pypa/flit/blob/${finalAttrs.version}/doc/history.rst";
     description = "Simple packaging tool for simple packages";
     mainProgram = "flit";
     homepage = "https://github.com/pypa/flit";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/python/pkgs/freezegun/default.nix
+++ b/python/pkgs/freezegun/default.nix
@@ -9,7 +9,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "freezegun";
   version = "1.5.4";
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-eYuTcv3U2QfzPotqWLxk5oLZ/6jUlM5g94AZfugfrtE=";
   };
 
@@ -36,11 +36,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "freezegun" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Library that allows your Python tests to travel through time";
     homepage = "https://github.com/spulec/freezegun";
-    changelog = "https://github.com/spulec/freezegun/blob/${version}/CHANGELOG";
+    changelog = "https://github.com/spulec/freezegun/blob/${finalAttrs.version}/CHANGELOG";
     license = lib.licenses.asl20;
 
   };
-}
+})

--- a/python/pkgs/freezegun/default.nix
+++ b/python/pkgs/freezegun/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = lib.optionals (pythonAtLeast "3.13") [
     # https://github.com/spulec/freezegun/issues/547
     "test_method_decorator_works_on_unittest_kwarg_frozen_time"
@@ -35,8 +37,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "freezegun" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Library that allows your Python tests to travel through time";

--- a/python/pkgs/func-timeout/default.nix
+++ b/python/pkgs/func-timeout/default.nix
@@ -18,6 +18,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = [
     # Calculates the amount of time the machine slept but doesn't account for heavy loads
     "test_retry"
@@ -28,8 +30,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "func_timeout" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Allows you to specify timeouts when calling any existing function. Also provides support for stoppable-threads";

--- a/python/pkgs/func-timeout/default.nix
+++ b/python/pkgs/func-timeout/default.nix
@@ -5,14 +5,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "func-timeout";
   version = "4.3.5";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "func_timeout";
-    inherit version;
+    inherit (finalAttrs) version;
     sha256 = "74cd3c428ec94f4edfba81f9b2f14904846d5ffccc27c92433b8b5939b5575dd";
   };
 
@@ -29,10 +29,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "func_timeout" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Allows you to specify timeouts when calling any existing function. Also provides support for stoppable-threads";
     homepage = "https://github.com/kata198/func_timeout";
     license = lib.licenses.lgpl3Only;
 
   };
-}
+})

--- a/python/pkgs/hatch-fancy-pypi-readme/default.nix
+++ b/python/pkgs/hatch-fancy-pypi-readme/default.nix
@@ -10,7 +10,7 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hatch-fancy-pypi-readme";
   version = "25.1.0";
   format = "pyproject";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     pname = "hatch_fancy_pypi_readme";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-nFjtPf+Q1R9DQUzjcAmtHVsPCP/J/CFpmKBjgPAcAEU=";
   };
 
@@ -44,6 +44,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hatch_fancy_pypi_readme" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Fancy PyPI READMEs with Hatch";
     mainProgram = "hatch-fancy-pypi-readme";
@@ -51,4 +53,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/hatch-fancy-pypi-readme/default.nix
+++ b/python/pkgs/hatch-fancy-pypi-readme/default.nix
@@ -36,6 +36,17 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  # The CLI end-to-end tests build the project against `AUTHORS.md` /
+  # `README.md` etc. at the source root.
+  testPaths = [
+    "tests"
+    "src"
+    "AUTHORS.md"
+    "CHANGELOG.md"
+    "LICENSE.txt"
+    "README.md"
+  ];
+
   # Requires network connection
   disabledTests = [
     "test_build" # Requires internet
@@ -43,8 +54,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "hatch_fancy_pypi_readme" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Fancy PyPI READMEs with Hatch";

--- a/python/pkgs/hatch-vcs/default.nix
+++ b/python/pkgs/hatch-vcs/default.nix
@@ -34,14 +34,14 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = [
     # reacts to our setup-hook pretending a version
     "test_custom_tag_pattern_get_version"
   ];
 
   pythonImportsCheck = [ "hatch_vcs" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://github.com/ofek/hatch-vcs/releases/tag/v${finalAttrs.version}";

--- a/python/pkgs/hatch-vcs/default.nix
+++ b/python/pkgs/hatch-vcs/default.nix
@@ -9,7 +9,7 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hatch-vcs";
   version = "0.5.0";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     pname = "hatch_vcs";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-A5X6EmlANAIVCQw0Siv04qd7y+faqxb0Gze5jJWAn/k=";
   };
 
@@ -41,11 +41,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hatch_vcs" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/ofek/hatch-vcs/releases/tag/v${version}";
+    changelog = "https://github.com/ofek/hatch-vcs/releases/tag/v${finalAttrs.version}";
     description = "Plugin for Hatch that uses your preferred version control system (like Git) to determine project versions";
     homepage = "https://github.com/ofek/hatch-vcs";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/hpack/default.nix
+++ b/python/pkgs/hpack/default.nix
@@ -26,9 +26,9 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "hpack" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "hpack" ];
 
   meta = {
     changelog = "https://github.com/python-hyper/hpack/blob/${finalAttrs.src.rev}/CHANGELOG.rst";

--- a/python/pkgs/hpack/default.nix
+++ b/python/pkgs/hpack/default.nix
@@ -7,7 +7,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hpack";
   version = "4.1.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "python-hyper";
     repo = "hpack";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-vbxfDlRDwMXuzkPO0oceCpSz1ekLNxLSj4iocdHo680=";
   };
 
@@ -28,11 +28,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hpack" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/python-hyper/hpack/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://github.com/python-hyper/hpack/blob/${finalAttrs.src.rev}/CHANGELOG.rst";
     description = "Pure-Python HPACK header compression";
     homepage = "https://github.com/python-hyper/hpack";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/hyperframe/default.nix
+++ b/python/pkgs/hyperframe/default.nix
@@ -20,9 +20,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "hyperframe" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "hyperframe" ];
 
   meta = {
     description = "HTTP/2 framing layer for Python";

--- a/python/pkgs/hyperframe/default.nix
+++ b/python/pkgs/hyperframe/default.nix
@@ -6,13 +6,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hyperframe";
   version = "6.1.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-9jCQigCFSnreq9Y4K0OSOkxM1Lgh/LUn5queFTgqOwg=";
   };
 
@@ -22,10 +22,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hyperframe" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "HTTP/2 framing layer for Python";
     homepage = "https://github.com/python-hyper/hyperframe/";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/idna/default.nix
+++ b/python/pkgs/idna/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  testPaths = [ "tests" ];
 
   meta = {
     homepage = "https://github.com/kjd/idna/";

--- a/python/pkgs/idna/default.nix
+++ b/python/pkgs/idna/default.nix
@@ -6,7 +6,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "idna";
   version = "3.11";
   pyproject = true;
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "kjd";
     repo = "idna";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-4mnWOit+lrZnVslVyfalt6lv7qSYpLlyvET553SplJU=";
   };
 
@@ -24,11 +24,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     homepage = "https://github.com/kjd/idna/";
-    changelog = "https://github.com/kjd/idna/releases/tag/${src.tag}";
+    changelog = "https://github.com/kjd/idna/releases/tag/${finalAttrs.src.tag}";
     description = "Internationalized Domain Names in Applications (IDNA)";
     license = lib.licenses.bsd3;
 
   };
-}
+})

--- a/python/pkgs/jaraco-classes/default.nix
+++ b/python/pkgs/jaraco-classes/default.nix
@@ -30,8 +30,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Utility functions for Python class constructs";
     homepage = "https://github.com/jaraco/jaraco.classes";

--- a/python/pkgs/jaraco-classes/default.nix
+++ b/python/pkgs/jaraco-classes/default.nix
@@ -8,7 +8,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jaraco-classes";
   version = "3.4.0";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "jaraco";
     repo = "jaraco.classes";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-pXDsLKiEru+UXcEBT4/cP1u8s9vSn1Zhf7Qnwy9Zr0I=";
   };
 
@@ -30,9 +30,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Utility functions for Python class constructs";
     homepage = "https://github.com/jaraco/jaraco.classes";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/jaraco-functools/default.nix
+++ b/python/pkgs/jaraco-functools/default.nix
@@ -10,14 +10,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jaraco-functools";
   version = "4.5.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "jaraco_functools";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-O7VmXqSgIM94pwQOiRVMd+2ts8p082ZHlmnFmZqnCwM=";
   };
 
@@ -44,11 +44,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jaraco.functools" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Additional functools in the spirit of stdlib's functools";
     homepage = "https://github.com/jaraco/jaraco.functools";
-    changelog = "https://github.com/jaraco/jaraco.functools/blob/v${version}/NEWS.rst";
+    changelog = "https://github.com/jaraco/jaraco.functools/blob/v${finalAttrs.version}/NEWS.rst";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/jaraco-functools/default.nix
+++ b/python/pkgs/jaraco-functools/default.nix
@@ -44,8 +44,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "jaraco.functools" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Additional functools in the spirit of stdlib's functools";
     homepage = "https://github.com/jaraco/jaraco.functools";

--- a/python/pkgs/jaraco-itertools/default.nix
+++ b/python/pkgs/jaraco-itertools/default.nix
@@ -38,8 +38,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "jaraco.itertools" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Tools for working with iterables";
     homepage = "https://github.com/jaraco/jaraco.itertools";

--- a/python/pkgs/jaraco-itertools/default.nix
+++ b/python/pkgs/jaraco-itertools/default.nix
@@ -8,7 +8,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jaraco-itertools";
   version = "6.4.3";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "jaraco";
     repo = "jaraco.itertools";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-LjWkyY9I8BBYpFm8TT3kq4vk63pNQrnZ15haJCQ5xlk=";
   };
 
@@ -38,9 +38,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jaraco.itertools" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Tools for working with iterables";
     homepage = "https://github.com/jaraco/jaraco.itertools";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/json-schema-for-humans/default.nix
+++ b/python/pkgs/json-schema-for-humans/default.nix
@@ -16,7 +16,7 @@
   requests,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "json-schema-for-humans";
   version = "1.5.1";
   pyproject = true;
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "coveooss";
     repo = "json-schema-for-humans";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-k4/+ijlaS/bjLcgobPcq6l4yX84WP1FwfGgYHw+iAdE=";
   };
 
@@ -67,12 +67,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "json_schema_for_humans" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Quickly generate HTML documentation from a JSON schema";
     homepage = "https://github.com/coveooss/json-schema-for-humans";
-    changelog = "https://github.com/coveooss/json-schema-for-humans/releases/tag/${src.tag}";
+    changelog = "https://github.com/coveooss/json-schema-for-humans/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
 
     mainProgram = "generate-schema-doc";
   };
-}
+})

--- a/python/pkgs/json-schema-for-humans/default.nix
+++ b/python/pkgs/json-schema-for-humans/default.nix
@@ -54,6 +54,11 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [
+    "tests"
+    "docs"
+  ];
+
   disabledTests = [
     # Tests require network access
     "test_references_url"
@@ -66,8 +71,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "json_schema_for_humans" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Quickly generate HTML documentation from a JSON schema";

--- a/python/pkgs/mako/default.nix
+++ b/python/pkgs/mako/default.nix
@@ -21,7 +21,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mako";
   version = "1.3.10";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sqlalchemy";
     repo = "mako";
-    tag = "rel_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "rel_${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-lxGlYyKbrDpr2LHcsqTow+s2l8+g+63M5j8xJt++tGo=";
   };
 
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.optional-dependencies;
 
   disabledTests = lib.optionals isPyPy [
     # https://github.com/sqlalchemy/mako/issues/315
@@ -61,6 +61,8 @@ buildPythonPackage rec {
     "test_bytestring_passthru"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Super-fast templating language";
     mainProgram = "mako-render";
@@ -70,4 +72,4 @@ buildPythonPackage rec {
     platforms = lib.platforms.unix;
 
   };
-}
+})

--- a/python/pkgs/mako/default.nix
+++ b/python/pkgs/mako/default.nix
@@ -51,6 +51,8 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.concatAttrValues finalAttrs.optional-dependencies;
 
+  testPaths = [ "test" ];
+
   disabledTests = lib.optionals isPyPy [
     # https://github.com/sqlalchemy/mako/issues/315
     "test_alternating_file_names"
@@ -60,8 +62,6 @@ buildPythonPackage (finalAttrs: {
     # fails on pypy2.7
     "test_bytestring_passthru"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Super-fast templating language";

--- a/python/pkgs/mock/default.nix
+++ b/python/pkgs/mock/default.nix
@@ -20,9 +20,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "mock" ];
+  testPaths = [ "mock" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "mock" ];
 
   meta = {
     description = "Rolling backport of unittest.mock for all Pythons";

--- a/python/pkgs/mock/default.nix
+++ b/python/pkgs/mock/default.nix
@@ -6,7 +6,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mock";
   version = "5.2.0";
   format = "setuptools";
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-TkYOgYYptLFz8y0IvzDTr4Ejr7uOBLtXB6H9R5nlA/A=";
   };
 
@@ -22,11 +22,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mock" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Rolling backport of unittest.mock for all Pythons";
     homepage = "https://github.com/testing-cabal/mock";
-    changelog = "https://github.com/testing-cabal/mock/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/testing-cabal/mock/blob/${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.bsd2;
 
   };
-}
+})

--- a/python/pkgs/more-itertools/default.nix
+++ b/python/pkgs/more-itertools/default.nix
@@ -26,11 +26,11 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   # iterable = range(10 ** 10)  # Is efficiently reversible
   # OverflowError: Python int too large to convert to C long
   doCheck = !stdenv.hostPlatform.is32bit;
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     homepage = "https://more-itertools.readthedocs.org";

--- a/python/pkgs/more-itertools/default.nix
+++ b/python/pkgs/more-itertools/default.nix
@@ -8,7 +8,7 @@
   stdenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "more-itertools";
   version = "11.0.2";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "more-itertools";
     repo = "more-itertools";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ZKM9+3l0qNclcQRNOEk8IF59xqyh1+uvdDRriG3Z/ek=";
   };
 
@@ -30,6 +30,8 @@ buildPythonPackage rec {
   # OverflowError: Python int too large to convert to C long
   doCheck = !stdenv.hostPlatform.is32bit;
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     homepage = "https://more-itertools.readthedocs.org";
     changelog = "https://more-itertools.readthedocs.io/en/stable/versions.html";
@@ -38,4 +40,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/mypy-extensions/default.nix
+++ b/python/pkgs/mypy-extensions/default.nix
@@ -7,7 +7,7 @@
   pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mypy-extensions";
   version = "1.1.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "python";
     repo = "mypy_extensions";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-HNAFsWX4tU9hfZkKxLNJn1J+H3uTesQflbRPlo3GQ4k=";
   };
 
@@ -33,10 +33,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mypy_extensions" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Experimental type system extensions for programs checked with the mypy typechecker";
     homepage = "https://www.mypy-lang.org";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/mypy-extensions/default.nix
+++ b/python/pkgs/mypy-extensions/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage (finalAttrs: {
   # make the testsuite run with pytest, so we can disable individual tests
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   enabledTestPaths = [ "tests/testextensions.py" ];
 
   disabledTests = lib.optionals (pythonAtLeast "3.14") [
@@ -32,8 +34,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "mypy_extensions" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Experimental type system extensions for programs checked with the mypy typechecker";

--- a/python/pkgs/netaddr/default.nix
+++ b/python/pkgs/netaddr/default.nix
@@ -7,13 +7,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "netaddr";
   version = "1.3.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-XDw9mJW1Ubdjd5un23oDSH3B+OOzha+BmvNBrp725Io=";
   };
 
@@ -35,13 +35,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "netaddr" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Network address manipulation library for Python";
     mainProgram = "netaddr";
     homepage = "https://netaddr.readthedocs.io/";
     downloadPage = "https://github.com/netaddr/netaddr/releases";
-    changelog = "https://github.com/netaddr/netaddr/blob/${version}/CHANGELOG";
+    changelog = "https://github.com/netaddr/netaddr/blob/${finalAttrs.version}/CHANGELOG";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/netaddr/default.nix
+++ b/python/pkgs/netaddr/default.nix
@@ -33,9 +33,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "netaddr" ];
+  testPaths = [ "netaddr/tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "netaddr" ];
 
   meta = {
     description = "Network address manipulation library for Python";

--- a/python/pkgs/numpy/1.nix
+++ b/python/pkgs/numpy/1.nix
@@ -57,14 +57,14 @@ let
     };
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "numpy";
   version = "1.26.4";
   pyproject = true;
   disabled = pythonOlder "3.9" || pythonAtLeast "3.13";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     extension = "tar.gz";
     hash = "sha256-KgKrqe0S5KxOs+qUIcQgMBoMZGDZgw10qd+H76SRIBA=";
   };
@@ -185,6 +185,7 @@ buildPythonPackage rec {
     coreIncludeDir = "${numpy_1}/${python.sitePackages}/numpy/core/include";
     tests = {
       inherit sage;
+      unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
     };
   };
 
@@ -193,10 +194,10 @@ buildPythonPackage rec {
   env.NOSE_EXCLUDE = "test_large_file_support";
 
   meta = {
-    changelog = "https://github.com/numpy/numpy/releases/tag/v${version}";
+    changelog = "https://github.com/numpy/numpy/releases/tag/v${finalAttrs.version}";
     description = "Scientific tools for Python";
     mainProgram = "f2py";
     homepage = "https://numpy.org/";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/python/pkgs/parso/default.nix
+++ b/python/pkgs/parso/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  testPaths = [ "test" ];
 
   meta = {
     description = "Python Parser";

--- a/python/pkgs/parso/default.nix
+++ b/python/pkgs/parso/default.nix
@@ -6,7 +6,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "parso";
   version = "0.8.5";
   pyproject = true;
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "davidhalter";
     repo = "parso";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-faSXCrOkybLr0bboF/8rPV/Humq8s158A3UOpdlYi0I=";
   };
 
@@ -22,10 +22,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Python Parser";
     homepage = "https://parso.readthedocs.io/en/latest/";
-    changelog = "https://github.com/davidhalter/parso/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/davidhalter/parso/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/pep517/default.nix
+++ b/python/pkgs/pep517/default.nix
@@ -14,13 +14,13 @@
   pip,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pep517";
   version = "0.13.1";
   format = "pyproject";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Gy+i/9OTi7S+/+XWFGy8sr2plqWk2p8xq//Ysk4Hsxc=";
   };
 
@@ -52,9 +52,11 @@ buildPythonPackage rec {
     rm tests/test_meta.py # wants to run pip
   '';
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Wrappers to build Python packages using PEP 517 hooks";
     license = lib.licenses.mit;
     homepage = "https://github.com/pypa/pep517";
   };
-}
+})

--- a/python/pkgs/pep517/default.nix
+++ b/python/pkgs/pep517/default.nix
@@ -42,17 +42,17 @@ buildPythonPackage (finalAttrs: {
     pip
   ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = [
     "test_setup_py"
     "test_issue_104"
   ];
 
   preCheck = ''
-    rm pytest.ini # wants flake8
-    rm tests/test_meta.py # wants to run pip
+    rm -f pytest.ini # wants flake8
+    rm -f tests/test_meta.py # wants to run pip
   '';
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Wrappers to build Python packages using PEP 517 hooks";

--- a/python/pkgs/pkginfo/default.nix
+++ b/python/pkgs/pkginfo/default.nix
@@ -6,13 +6,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pkginfo";
   version = "1.12.1.2";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-XNlXgkrDbxQCYJZOujxr5kQqg1m4xI9K35AhDzOgS3s=";
   };
 
@@ -31,6 +31,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pkginfo" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     changelog = "https://pypi.org/project/pkginfo/#pkginfo-changelog";
     description = "Query metadatdata from sdists, bdists or installed packages";
@@ -41,9 +43,9 @@ buildPythonPackage rec {
       written in the PKG-INFO file inside a source distriubtion (an sdist)
       or a binary distribution (e.g., created by running bdist_egg). It can
       also query the EGG-INFO directory of an installed distribution, and the
-      *.egg-info stored in a “development checkout” (e.g, created by running
+      *.egg-info stored in a "development checkout" (e.g, created by running
       setup.py develop).
     '';
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/pkginfo/default.nix
+++ b/python/pkgs/pkginfo/default.nix
@@ -20,6 +20,12 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  # The test suite reads example metadata from `docs/examples/`.
+  testPaths = [
+    "pkginfo"
+    "docs"
+  ];
+
   disabledTests = [
     # wheel metadata version mismatch 2.1 vs 2.2
     "test_get_metadata_w_module"
@@ -30,8 +36,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "pkginfo" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://pypi.org/project/pkginfo/#pkginfo-changelog";

--- a/python/pkgs/pretend/default.nix
+++ b/python/pkgs/pretend/default.nix
@@ -24,8 +24,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "pretend" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Module for stubbing";
     homepage = "https://github.com/alex/pretend";

--- a/python/pkgs/pretend/default.nix
+++ b/python/pkgs/pretend/default.nix
@@ -6,7 +6,7 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pretend";
   version = "1.0.9";
   format = "setuptools";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "alex";
     repo = "pretend";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-OqMfeIMFNBBLq6ejR3uOCIHZ9aA4zew7iefVlAsy1JQ=";
   };
 
@@ -24,10 +24,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pretend" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Module for stubbing";
     homepage = "https://github.com/alex/pretend";
     license = lib.licenses.bsd3;
 
   };
-}
+})

--- a/python/pkgs/prompt-toolkit/default.nix
+++ b/python/pkgs/prompt-toolkit/default.nix
@@ -7,7 +7,7 @@
   wcwidth,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "prompt-toolkit";
   version = "3.0.52";
   pyproject = true;
@@ -15,14 +15,14 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "prompt-toolkit";
     repo = "python-prompt-toolkit";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-ggCy7xTvOkjy6DgsO/rPNtQiAQ4FjsK4ShrvkIHioNQ=";
   };
 
   postPatch = ''
     # https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1988
     substituteInPlace src/prompt_toolkit/__init__.py \
-      --replace-fail 'metadata.version("prompt_toolkit")' '"${version}"'
+      --replace-fail 'metadata.version("prompt_toolkit")' '"${finalAttrs.version}"'
   '';
 
   build-system = [ setuptools ];
@@ -39,6 +39,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "prompt_toolkit" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Python library for building powerful interactive command lines";
     longDescription = ''
@@ -48,7 +50,7 @@ buildPythonPackage rec {
       with a nice interactive Python shell (called ptpython) built on top.
     '';
     homepage = "https://github.com/jonathanslenders/python-prompt-toolkit";
-    changelog = "https://github.com/prompt-toolkit/python-prompt-toolkit/releases/tag/${src.tag}";
+    changelog = "https://github.com/prompt-toolkit/python-prompt-toolkit/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/python/pkgs/prompt-toolkit/default.nix
+++ b/python/pkgs/prompt-toolkit/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = [
     # tests/test_completion.py:206: AssertionError
     # https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1657
@@ -38,8 +40,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "prompt_toolkit" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Python library for building powerful interactive command lines";

--- a/python/pkgs/psutil/default.nix
+++ b/python/pkgs/psutil/default.nix
@@ -33,6 +33,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "psutil/tests" ];
+
   # Segfaults on darwin:
   # https://github.com/giampaolo/psutil/issues/1715
   doCheck = !stdenv.hostPlatform.isDarwin;
@@ -64,8 +66,6 @@ buildPythonPackage (finalAttrs: {
   passthru.updateScript = gitUpdater {
     rev-prefix = "release-";
   };
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Process and system utilization information interface";

--- a/python/pkgs/psutil/default.nix
+++ b/python/pkgs/psutil/default.nix
@@ -9,7 +9,7 @@
   gitUpdater,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "psutil";
   version = "7.1.2";
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "giampaolo";
     repo = "psutil";
-    tag = "release-${version}";
+    tag = "release-${finalAttrs.version}";
     hash = "sha256-LyGnLrq+SzCQmz8/P5DOugoNEyuH0IC7uIp8UAPwH0U=";
   };
 
@@ -65,11 +65,13 @@ buildPythonPackage rec {
     rev-prefix = "release-";
   };
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Process and system utilization information interface";
     homepage = "https://github.com/giampaolo/psutil";
-    changelog = "https://github.com/giampaolo/psutil/blob/${src.tag}/HISTORY.rst";
+    changelog = "https://github.com/giampaolo/psutil/blob/${finalAttrs.src.tag}/HISTORY.rst";
     license = lib.licenses.bsd3;
 
   };
-}
+})

--- a/python/pkgs/ptyprocess/default.nix
+++ b/python/pkgs/ptyprocess/default.nix
@@ -8,7 +8,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ptyprocess";
   version = "0.7.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-XF0KO0jO7gtISF4MJgN8Cs19KXZco/u1yzgx00dCMiA=";
   };
 
@@ -38,11 +38,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ptyprocess" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Run a subprocess in a pseudo terminal";
     homepage = "https://github.com/pexpect/ptyprocess";
-    changelog = "https://github.com/pexpect/ptyprocess/releases/tag/${version}";
+    changelog = "https://github.com/pexpect/ptyprocess/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
 
   };
-}
+})

--- a/python/pkgs/ptyprocess/default.nix
+++ b/python/pkgs/ptyprocess/default.nix
@@ -36,9 +36,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "ptyprocess" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "ptyprocess" ];
 
   meta = {
     description = "Run a subprocess in a pseudo terminal";

--- a/python/pkgs/pycodestyle/default.nix
+++ b/python/pkgs/pycodestyle/default.nix
@@ -26,6 +26,15 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  # `tests/` imports the `testing` helper module and `postCheck` lints
+  # `pycodestyle.py` from the source root.
+  testPaths = [
+    "tests"
+    "testing"
+    "pycodestyle.py"
+    "setup.py"
+  ];
+
   # https://github.com/PyCQA/pycodestyle/blob/2.14.0/tox.ini#L16
   postCheck = ''
     ${python.interpreter} -m pycodestyle --statistics pycodestyle.py
@@ -35,8 +44,6 @@ buildPythonPackage (finalAttrs: {
     # PyPy reports a SyntaxError instead of ValueError
     "test_check_nullbytes"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://github.com/PyCQA/pycodestyle/blob/${finalAttrs.src.tag}/CHANGES.txt";

--- a/python/pkgs/pycodestyle/default.nix
+++ b/python/pkgs/pycodestyle/default.nix
@@ -8,7 +8,7 @@
   isPyPy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pycodestyle";
   version = "2.14.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = "pycodestyle";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-1EEQp/QEulrdU9tTe28NerQ33IWlAiSlicpmNYciW88=";
   };
 
@@ -36,12 +36,14 @@ buildPythonPackage rec {
     "test_check_nullbytes"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/PyCQA/pycodestyle/blob/${src.tag}/CHANGES.txt";
+    changelog = "https://github.com/PyCQA/pycodestyle/blob/${finalAttrs.src.tag}/CHANGES.txt";
     description = "Python style guide checker";
     mainProgram = "pycodestyle";
     homepage = "https://pycodestyle.pycqa.org/";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/pyflakes/default.nix
+++ b/python/pkgs/pyflakes/default.nix
@@ -23,6 +23,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "pyflakes/test" ];
+
   disabledTests = lib.optionals isPyPy [
     # https://github.com/PyCQA/pyflakes/issues/779
     "test_eofSyntaxError"
@@ -32,8 +34,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "pyflakes" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     homepage = "https://github.com/PyCQA/pyflakes";

--- a/python/pkgs/pyflakes/default.nix
+++ b/python/pkgs/pyflakes/default.nix
@@ -7,7 +7,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyflakes";
   version = "3.4.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = "pyflakes";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-4UEJjn9Eey1vHeaG468x/nMlbfGu3ohZX1R7RR2R5ik=";
   };
 
@@ -33,12 +33,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyflakes" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     homepage = "https://github.com/PyCQA/pyflakes";
-    changelog = "https://github.com/PyCQA/pyflakes/blob/${src.tag}/NEWS.rst";
+    changelog = "https://github.com/PyCQA/pyflakes/blob/${finalAttrs.src.tag}/NEWS.rst";
     description = "Simple program which checks Python source files for errors";
     mainProgram = "pyflakes";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/pyopenssl/default.nix
+++ b/python/pkgs/pyopenssl/default.nix
@@ -53,6 +53,8 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [ "tests" ];
+
   __darwinAllowLocalNetworking = true;
 
   disabledTests = [
@@ -94,8 +96,6 @@ buildPythonPackage (finalAttrs: {
     # https://github.com/pyca/pyopenssl/issues/974
     "test_verify_with_time"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Python wrapper around the OpenSSL library";

--- a/python/pkgs/pyopenssl/default.nix
+++ b/python/pkgs/pyopenssl/default.nix
@@ -14,7 +14,7 @@
   pytest-rerunfailures,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyopenssl";
   version = "25.3.0";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pyca";
     repo = "pyopenssl";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-lNXS3lIGFPeM7DKMFTLBiOWn+AwZtenXF5KGN5DRwO4=";
   };
 
@@ -95,11 +95,13 @@ buildPythonPackage rec {
     "test_verify_with_time"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Python wrapper around the OpenSSL library";
     homepage = "https://github.com/pyca/pyopenssl";
-    changelog = "https://github.com/pyca/pyopenssl/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/pyca/pyopenssl/blob/${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/pytest-mock/default.nix
+++ b/python/pkgs/pytest-mock/default.nix
@@ -33,9 +33,9 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "pytest_mock" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "pytest_mock" ];
 
   meta = {
     description = "Thin wrapper around the mock package for easier use with pytest";

--- a/python/pkgs/pytest-mock/default.nix
+++ b/python/pkgs/pytest-mock/default.nix
@@ -9,7 +9,7 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-mock";
   version = "3.15.1";
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-mock";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-9h5/cssWs4F0LKnFLjWDsEjB2AYczLvnSjiUdsaEcBQ=";
   };
 
@@ -35,11 +35,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest_mock" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Thin wrapper around the mock package for easier use with pytest";
     homepage = "https://github.com/pytest-dev/pytest-mock";
-    changelog = "https://github.com/pytest-dev/pytest-mock/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/pytest-dev/pytest-mock/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/pytest-rerunfailures/default.nix
+++ b/python/pkgs/pytest-rerunfailures/default.nix
@@ -9,7 +9,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-rerunfailures";
   version = "16.0.1";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-rerunfailures";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-4/BgvfVcs7MdULlhafZypNzzag4ITALStHI1tIoAPL4=";
   };
 
@@ -31,11 +31,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Pytest plugin to re-run tests to eliminate flaky failures";
     homepage = "https://github.com/pytest-dev/pytest-rerunfailures";
-    changelog = "https://github.com/pytest-dev/pytest-rerunfailures/blob/${src.tag}/CHANGES.rst";
+    changelog = "https://github.com/pytest-dev/pytest-rerunfailures/blob/${finalAttrs.src.tag}/CHANGES.rst";
     license = lib.licenses.mpl20;
 
   };
-}
+})

--- a/python/pkgs/pytest-rerunfailures/default.nix
+++ b/python/pkgs/pytest-rerunfailures/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  testPaths = [ "tests" ];
 
   meta = {
     description = "Pytest plugin to re-run tests to eliminate flaky failures";

--- a/python/pkgs/pytest-timeout/default.nix
+++ b/python/pkgs/pytest-timeout/default.nix
@@ -31,8 +31,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "pytest_timeout" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Pytest plugin to abort hanging tests";
     homepage = "https://github.com/pytest-dev/pytest-timeout/";

--- a/python/pkgs/pytest-timeout/default.nix
+++ b/python/pkgs/pytest-timeout/default.nix
@@ -8,7 +8,7 @@
   pexpect,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-timeout";
   version = "2.4.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-timeout";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-NGTy3Hua6yEMWXQDJQO2Z5DD3clXTZXEH6DNQBMSGtQ=";
   };
 
@@ -31,11 +31,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest_timeout" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Pytest plugin to abort hanging tests";
     homepage = "https://github.com/pytest-dev/pytest-timeout/";
-    changelog = "https://github.com/pytest-dev/pytest-timeout/tree/${src.tag}#changelog";
+    changelog = "https://github.com/pytest-dev/pytest-timeout/tree/${finalAttrs.src.tag}#changelog";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/pyyaml/default.nix
+++ b/python/pkgs/pyyaml/default.nix
@@ -9,7 +9,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyyaml";
   version = "6.0.3";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "yaml";
     repo = "pyyaml";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-jUooIBp80cLxvdU/zLF0X8Yjrf0Yp9peYeiFjuV8AHA=";
   };
 
@@ -34,11 +34,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/yaml/pyyaml/blob/${src.rev}/CHANGES";
+    changelog = "https://github.com/yaml/pyyaml/blob/${finalAttrs.src.rev}/CHANGES";
     description = "Next generation YAML parser and emitter for Python";
     homepage = "https://github.com/yaml/pyyaml";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/pyyaml/default.nix
+++ b/python/pkgs/pyyaml/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  testPaths = [ "tests" ];
 
   meta = {
     changelog = "https://github.com/yaml/pyyaml/blob/${finalAttrs.src.rev}/CHANGES";

--- a/python/pkgs/requests/default.nix
+++ b/python/pkgs/requests/default.nix
@@ -75,14 +75,14 @@ buildPythonPackage (finalAttrs: {
     "test_text_response"
   ];
 
+  testPaths = [ "tests" ];
+
   disabledTestPaths = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
     # Fatal Python error: Aborted
     "tests/test_lowlevel.py"
   ];
 
   pythonImportsCheck = [ "requests" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "HTTP library for Python";

--- a/python/pkgs/requests/default.nix
+++ b/python/pkgs/requests/default.nix
@@ -16,7 +16,7 @@
   urllib3,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "requests";
   version = "2.32.5";
   pyproject = true;
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "psf";
     repo = "requests";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-cEBalMFoYFaGG8M48k+OEBvzLegzrTNP1NxH2ljP6qg=";
   };
 
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
   ]
-  ++ optional-dependencies.socks;
+  ++ finalAttrs.optional-dependencies.socks;
 
   disabledTests = [
     # Disable tests that require network access and use httpbin
@@ -82,11 +82,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "requests" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "HTTP library for Python";
     homepage = "http://docs.python-requests.org/";
-    changelog = "https://github.com/psf/requests/blob/v${version}/HISTORY.md";
+    changelog = "https://github.com/psf/requests/blob/v${finalAttrs.version}/HISTORY.md";
     license = lib.licenses.asl20;
 
   };
-}
+})

--- a/python/pkgs/responses/default.nix
+++ b/python/pkgs/responses/default.nix
@@ -50,9 +50,9 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  pythonImportsCheck = [ "responses" ];
+  testPaths = [ "responses/tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "responses" ];
 
   meta = {
     description = "Python module for mocking out the requests Python library";

--- a/python/pkgs/responses/default.nix
+++ b/python/pkgs/responses/default.nix
@@ -16,7 +16,7 @@
   urllib3,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "responses";
   version = "0.25.7";
   pyproject = true;
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "getsentry";
     repo = "responses";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-eiJwu0sRtr3S4yAnbsIak7g03CNqOTS16rNXoXRQumA=";
   };
 
@@ -52,11 +52,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "responses" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Python module for mocking out the requests Python library";
     homepage = "https://github.com/getsentry/responses";
-    changelog = "https://github.com/getsentry/responses/blob/${src.tag}/CHANGES";
+    changelog = "https://github.com/getsentry/responses/blob/${finalAttrs.src.tag}/CHANGES";
     license = lib.licenses.asl20;
 
   };
-}
+})

--- a/python/pkgs/roman-numerals-py/default.nix
+++ b/python/pkgs/roman-numerals-py/default.nix
@@ -30,9 +30,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "roman_numerals" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "roman_numerals" ];
 
   meta = {
     description = "Manipulate roman numerals";

--- a/python/pkgs/roman-numerals-py/default.nix
+++ b/python/pkgs/roman-numerals-py/default.nix
@@ -7,7 +7,7 @@
   sphinx,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "roman-numerals-py";
   version = "3.1.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "AA-Turner";
     repo = "roman-numerals";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-YLF09jYwXq48iMvmqbj/cocYJPp7RsCXzbN0DV9gpis=";
   };
 
@@ -32,12 +32,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "roman_numerals" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Manipulate roman numerals";
     homepage = "https://github.com/AA-Turner/roman-numerals/";
-    changelog = "https://github.com/AA-Turner/roman-numerals/blob/${src.tag}/CHANGES.rst";
+    changelog = "https://github.com/AA-Turner/roman-numerals/blob/${finalAttrs.src.tag}/CHANGES.rst";
     license = lib.licenses.cc0;
     mainProgram = "roman-numerals-py";
     platforms = lib.platforms.all;
   };
-}
+})

--- a/python/pkgs/scikit-build-core/default.nix
+++ b/python/pkgs/scikit-build-core/default.nix
@@ -17,7 +17,7 @@
   tomli,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "scikit-build-core";
   version = "0.11.5";
   pyproject = true;
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "scikit-build";
     repo = "scikit-build-core";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-4DwODJw1U/0+K/d7znYtDO2va71lzp1gDm4Bg9OBjQY=";
   };
 
@@ -79,11 +79,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "scikit_build_core" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Next generation Python CMake adaptor and Python API for plugins";
     homepage = "https://github.com/scikit-build/scikit-build-core";
-    changelog = "https://github.com/scikit-build/scikit-build-core/blob/${src.tag}/docs/about/changelog.md";
+    changelog = "https://github.com/scikit-build/scikit-build-core/blob/${finalAttrs.src.tag}/docs/about/changelog.md";
     license = with lib.licenses; [ asl20 ];
 
   };
-}
+})

--- a/python/pkgs/scikit-build-core/default.nix
+++ b/python/pkgs/scikit-build-core/default.nix
@@ -72,14 +72,14 @@ buildPythonPackage (finalAttrs: {
     "network"
   ];
 
+  testPaths = [ "tests" ];
+
   disabledTestPaths = [
     # store permissions issue in Nix:
     "tests/test_editable.py"
   ];
 
   pythonImportsCheck = [ "scikit_build_core" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Next generation Python CMake adaptor and Python API for plugins";

--- a/python/pkgs/semantic-version/default.nix
+++ b/python/pkgs/semantic-version/default.nix
@@ -5,14 +5,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "semantic-version";
   version = "2.10.0";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "semantic_version";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-vau20zaZjLs3jUuds6S1ah4yNXAdwF6iaQ2amX7VBBw=";
   };
 
@@ -20,10 +20,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "semantic_version" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Library implementing the 'SemVer' scheme";
     homepage = "https://github.com/rbarrois/python-semanticversion/";
     license = lib.licenses.bsd2;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/semantic-version/default.nix
+++ b/python/pkgs/semantic-version/default.nix
@@ -18,9 +18,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "semantic_version" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "semantic_version" ];
 
   meta = {
     description = "Library implementing the 'SemVer' scheme";

--- a/python/pkgs/shellingham/default.nix
+++ b/python/pkgs/shellingham/default.nix
@@ -36,6 +36,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "shellingham" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Tool to detect the surrounding shell";
     homepage = "https://github.com/sarugaku/shellingham";

--- a/python/pkgs/shellingham/default.nix
+++ b/python/pkgs/shellingham/default.nix
@@ -34,9 +34,9 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "shellingham" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "shellingham" ];
 
   meta = {
     description = "Tool to detect the surrounding shell";

--- a/python/pkgs/six/default.nix
+++ b/python/pkgs/six/default.nix
@@ -7,7 +7,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "six";
   version = "1.17.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "benjaminp";
     repo = "six";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-tz99C+dz5xJhunoC45bl0NdSdV9NXWya9ti48Z/KaHY=";
   };
 
@@ -30,11 +30,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "six" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
-    changelog = "https://github.com/benjaminp/six/blob/${version}/CHANGES";
+    changelog = "https://github.com/benjaminp/six/blob/${finalAttrs.version}/CHANGES";
     description = "Python 2 and 3 compatibility library";
     homepage = "https://github.com/benjaminp/six";
     license = lib.licenses.mit;
 
   };
-}
+})

--- a/python/pkgs/six/default.nix
+++ b/python/pkgs/six/default.nix
@@ -30,8 +30,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "six" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     changelog = "https://github.com/benjaminp/six/blob/${finalAttrs.version}/CHANGES";
     description = "Python 2 and 3 compatibility library";

--- a/python/pkgs/smartypants/default.nix
+++ b/python/pkgs/smartypants/default.nix
@@ -9,7 +9,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "smartypants";
   version = "2.0.2";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "leohemsted";
     repo = "smartypants.py";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-jSGiT36Rr0P6eEWZIHtMj4go3KGDRaF2spLxLNruDec=";
   };
 
@@ -35,12 +35,14 @@ buildPythonPackage rec {
     patchShebangs smartypants
   '';
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Translate plain ASCII quotation marks and other characters into “smart” typographic HTML entities";
     homepage = "https://github.com/leohemsted/smartypants.py";
-    changelog = "https://github.com/leohemsted/smartypants.py/blob/v${version}/CHANGES.rst";
+    changelog = "https://github.com/leohemsted/smartypants.py/blob/v${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.bsd3;
 
     mainProgram = "smartypants";
   };
-}
+})

--- a/python/pkgs/smartypants/default.nix
+++ b/python/pkgs/smartypants/default.nix
@@ -31,11 +31,17 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  # The tests reference the `smartypants` CLI script and `README.rst` at the
+  # source root, so bundle them into the `test_src` output.
+  testPaths = [
+    "tests"
+    "smartypants"
+    "README.rst"
+  ];
+
   preCheck = ''
     patchShebangs smartypants
   '';
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Translate plain ASCII quotation marks and other characters into “smart” typographic HTML entities";

--- a/python/pkgs/sphinx-rtd-theme/default.nix
+++ b/python/pkgs/sphinx-rtd-theme/default.nix
@@ -9,14 +9,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "sphinx-rtd-theme";
   version = "3.1.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "sphinx_rtd_theme";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-tEJ28sJ26Qkjmk9slVqmZ6qv63hZeSOxxgurx223jkw=";
   };
 
@@ -51,10 +51,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "sphinx_rtd_theme" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Sphinx theme for readthedocs.org";
     homepage = "https://github.com/readthedocs/sphinx_rtd_theme";
-    changelog = "https://github.com/readthedocs/sphinx_rtd_theme/blob/${version}/docs/changelog.rst";
+    changelog = "https://github.com/readthedocs/sphinx_rtd_theme/blob/${finalAttrs.version}/docs/changelog.rst";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/sphinx-rtd-theme/default.nix
+++ b/python/pkgs/sphinx-rtd-theme/default.nix
@@ -44,14 +44,14 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = [
     # docutils 0.21 compat
     "test_basic"
   ];
 
   pythonImportsCheck = [ "sphinx_rtd_theme" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Sphinx theme for readthedocs.org";

--- a/python/pkgs/sphinxcontrib-jquery/default.nix
+++ b/python/pkgs/sphinxcontrib-jquery/default.nix
@@ -48,9 +48,9 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  pythonNamespaces = [ "sphinxcontrib" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonNamespaces = [ "sphinxcontrib" ];
 
   meta = {
     description = "Extension to include jQuery on newer Sphinx releases";

--- a/python/pkgs/sphinxcontrib-jquery/default.nix
+++ b/python/pkgs/sphinxcontrib-jquery/default.nix
@@ -9,7 +9,7 @@
   sphinx,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "sphinxcontrib-jquery";
   version = "4.1";
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sphinx-contrib";
     repo = "jquery";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ZQGQcVmhWREFa2KyaOKdTz5W2AS2ur7pFp8qZ2IkxSE=";
   };
 
@@ -50,6 +50,8 @@ buildPythonPackage rec {
 
   pythonNamespaces = [ "sphinxcontrib" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Extension to include jQuery on newer Sphinx releases";
     longDescription = ''
@@ -57,7 +59,7 @@ buildPythonPackage rec {
       in Sphinx themes or extensions
     '';
     homepage = "https://github.com/sphinx-contrib/jquery";
-    changelog = "https://github.com/sphinx-contrib/jquery/blob/v${version}/CHANGES.rst";
+    changelog = "https://github.com/sphinx-contrib/jquery/blob/v${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.bsd0;
   };
-}
+})

--- a/python/pkgs/testpath/default.nix
+++ b/python/pkgs/testpath/default.nix
@@ -21,6 +21,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "tests" ];
+
   # exe are only required when testpath is used on windows
   # https://github.com/jupyter/testpath/blob/de8ca59539eb23b9781e55848b7d2646c8c61df9/testpath/commands.py#L128
   preBuild = lib.optionalString (!stdenv.hostPlatform.isWindows) ''
@@ -31,8 +33,6 @@ buildPythonPackage (finalAttrs: {
     # Work around https://github.com/jupyter/testpath/issues/24
     export TMPDIR="/tmp"
   '';
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Test utilities for code working with files and commands";

--- a/python/pkgs/testpath/default.nix
+++ b/python/pkgs/testpath/default.nix
@@ -7,13 +7,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "testpath";
   version = "0.6.0";
   format = "pyproject";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-LxuX5kQsAmgevgG9hPUxAop8rqGvOCUAD1I0XDAoXg8=";
   };
 
@@ -32,9 +32,11 @@ buildPythonPackage rec {
     export TMPDIR="/tmp"
   '';
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Test utilities for code working with files and commands";
     license = lib.licenses.mit;
     homepage = "https://github.com/jupyter/testpath";
   };
-}
+})

--- a/python/pkgs/tomli-w/default.nix
+++ b/python/pkgs/tomli-w/default.nix
@@ -7,7 +7,7 @@
   tomli,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tomli-w";
   version = "1.2.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "hukkin";
     repo = "tomli-w";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-Du37ySvAL9iwGec5wbWxwLTYm+kcDSOs5OJ5Sw7R87g=";
   };
 
@@ -28,10 +28,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "tomli_w" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Write-only counterpart to Tomli, which is a read-only TOML parser";
     homepage = "https://github.com/hukkin/tomli-w";
-    changelog = "https://github.com/hukkin/tomli-w/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/hukkin/tomli-w/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/tomli-w/default.nix
+++ b/python/pkgs/tomli-w/default.nix
@@ -26,9 +26,14 @@ buildPythonPackage (finalAttrs: {
     tomli
   ];
 
-  pythonImportsCheck = [ "tomli_w" ];
+  # `tests/test_for_profiler.py` reads a TOML file from the sibling
+  # `benchmark/` directory.
+  testPaths = [
+    "tests"
+    "benchmark"
+  ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "tomli_w" ];
 
   meta = {
     description = "Write-only counterpart to Tomli, which is a read-only TOML parser";

--- a/python/pkgs/tomlkit/default.nix
+++ b/python/pkgs/tomlkit/default.nix
@@ -28,9 +28,9 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "tomlkit" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "tomlkit" ];
 
   meta = {
     homepage = "https://github.com/sdispater/tomlkit";

--- a/python/pkgs/tomlkit/default.nix
+++ b/python/pkgs/tomlkit/default.nix
@@ -11,13 +11,13 @@
   pyyaml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tomlkit";
   version = "0.13.3";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-QwzyR+5X3yuU7j++WI5x02KpQeu1Rd7Cm1OWHWGt0qE=";
   };
 
@@ -30,10 +30,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "tomlkit" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     homepage = "https://github.com/sdispater/tomlkit";
-    changelog = "https://github.com/sdispater/tomlkit/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/sdispater/tomlkit/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "Style-preserving TOML library for Python";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/typing-inspect/default.nix
+++ b/python/pkgs/typing-inspect/default.nix
@@ -32,8 +32,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "typing_inspect" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Runtime inspection utilities for Python typing module";
     homepage = "https://github.com/ilevkivskyi/typing_inspect";

--- a/python/pkgs/typing-inspect/default.nix
+++ b/python/pkgs/typing-inspect/default.nix
@@ -7,13 +7,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "typing-inspect";
   version = "0.9.0";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "typing_inspect";
     hash = "sha256-sj/EL/b272lU5IUsH7USzdGNvqAxNPkfhWqVzMlGH3g=";
   };
@@ -32,9 +32,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "typing_inspect" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Runtime inspection utilities for Python typing module";
     homepage = "https://github.com/ilevkivskyi/typing_inspect";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/typogrify/default.nix
+++ b/python/pkgs/typogrify/default.nix
@@ -8,7 +8,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "typogrify";
   version = "2.1.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-8KoATpgDKm5r5MnaZefrcVDjbKO/UIrbzagrTQA+Ye4=";
   };
 
@@ -39,9 +39,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Filters to enhance web typography, including support for Django & Jinja templates";
     homepage = "https://github.com/justinmayer/typogrify";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/python/pkgs/typogrify/default.nix
+++ b/python/pkgs/typogrify/default.nix
@@ -39,8 +39,6 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Filters to enhance web typography, including support for Django & Jinja templates";
     homepage = "https://github.com/justinmayer/typogrify";

--- a/python/pkgs/wcag-contrast-ratio/default.nix
+++ b/python/pkgs/wcag-contrast-ratio/default.nix
@@ -6,13 +6,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "wcag-contrast-ratio";
   version = "0.9";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-aRkrjlwKfQ3F/xGH7rPjmBQWM6S95RxpyH9Y/oftNhw=";
   };
 
@@ -25,9 +25,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "wcag_contrast_ratio" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Library for computing contrast ratios, as required by WCAG 2.0";
     homepage = "https://github.com/gsnedders/wcag-contrast-ratio";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/wcag-contrast-ratio/default.nix
+++ b/python/pkgs/wcag-contrast-ratio/default.nix
@@ -25,8 +25,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "wcag_contrast_ratio" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Library for computing contrast ratios, as required by WCAG 2.0";
     homepage = "https://github.com/gsnedders/wcag-contrast-ratio";

--- a/python/pkgs/xmlschema/default.nix
+++ b/python/pkgs/xmlschema/default.nix
@@ -34,6 +34,8 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [ "tests" ];
+
   disabledTests = [
     # Incorrect error message in pickling test for Python 3.12 in Debian
     # https://github.com/sissaschool/xmlschema/issues/412
@@ -41,8 +43,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "xmlschema" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "XML Schema validator and data conversion library for Python";

--- a/python/pkgs/xmlschema/default.nix
+++ b/python/pkgs/xmlschema/default.nix
@@ -10,7 +10,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xmlschema";
   version = "4.2.0";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sissaschool";
     repo = "xmlschema";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-zwY0YXMlhQEPdHLPivwE9ZI9XoY9UVFHVLUOYNeq9Ew=";
   };
 
@@ -42,10 +42,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "xmlschema" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "XML Schema validator and data conversion library for Python";
     homepage = "https://github.com/sissaschool/xmlschema";
-    changelog = "https://github.com/sissaschool/xmlschema/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/sissaschool/xmlschema/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.mit;
   };
-}
+})

--- a/python/pkgs/xmltodict/default.nix
+++ b/python/pkgs/xmltodict/default.nix
@@ -22,9 +22,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "xmltodict" ];
+  testPaths = [ "tests" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+  pythonImportsCheck = [ "xmltodict" ];
 
   meta = {
     description = "Makes working with XML feel like you are working with JSON";

--- a/python/pkgs/xmltodict/default.nix
+++ b/python/pkgs/xmltodict/default.nix
@@ -6,7 +6,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xmltodict";
   version = "1.0.2";
   pyproject = true;
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "martinblech";
     repo = "xmltodict";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-gnTNkh0GLfRmjMsLhfvpNrewfinNOhem0i3wzIZvKpA=";
   };
 
@@ -24,11 +24,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "xmltodict" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Makes working with XML feel like you are working with JSON";
     homepage = "https://github.com/martinblech/xmltodict";
-    changelog = "https://github.com/martinblech/xmltodict/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/martinblech/xmltodict/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/python/pkgs/yq/default.nix
+++ b/python/pkgs/yq/default.nix
@@ -43,11 +43,11 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [ "test" ];
+
   enabledTestPaths = [ "test/test.py" ];
 
   pythonImportsCheck = [ "yq" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Command-line YAML/XML/TOML processor - jq wrapper for YAML, XML, TOML documents";

--- a/python/pkgs/yq/default.nix
+++ b/python/pkgs/yq/default.nix
@@ -13,13 +13,13 @@
   xmltodict,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "yq";
   version = "3.4.3";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-ulhqGm8wz3BbL5IgZxLfIoHNMgKAIQ57e4Cty48lbjs=";
   };
 
@@ -47,6 +47,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "yq" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Command-line YAML/XML/TOML processor - jq wrapper for YAML, XML, TOML documents";
     homepage = "https://github.com/kislyuk/yq";
@@ -54,4 +56,4 @@ buildPythonPackage rec {
     maintainers = [ ];
     mainProgram = "yq";
   };
-}
+})

--- a/python/pkgs/zlib-ng/default.nix
+++ b/python/pkgs/zlib-ng/default.nix
@@ -16,7 +16,7 @@
 let
   inherit (pkgs) zlib-ng;
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "zlib-ng";
   version = "1.0.0";
   pyproject = true;
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pycompression";
     repo = "python-zlib-ng";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-t/PSby1LUTyp+7XXKZTWjRrPvAei1ZrGSGU2CIcAQBc=";
   };
 
@@ -58,10 +58,12 @@ buildPythonPackage rec {
     "test_decompress_infile_outfile_error"
   ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Drop-in replacement for Python's zlib and gzip modules using zlib-ng";
     homepage = "https://github.com/pycompression/python-zlib-ng";
-    changelog = "https://github.com/pycompression/python-zlib-ng/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://github.com/pycompression/python-zlib-ng/blob/${finalAttrs.src.rev}/CHANGELOG.rst";
     license = lib.licenses.psfl;
   };
-}
+})

--- a/python/pkgs/zlib-ng/default.nix
+++ b/python/pkgs/zlib-ng/default.nix
@@ -44,6 +44,11 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  testPaths = [
+    "tests"
+    "README.rst"
+  ];
+
   preCheck = ''
     rm -rf src
   '';
@@ -57,8 +62,6 @@ buildPythonPackage (finalAttrs: {
     "test_decompress_infile_outfile"
     "test_decompress_infile_outfile_error"
   ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Drop-in replacement for Python's zlib and gzip modules using zlib-ng";

--- a/python/pkgs/zope-event/default.nix
+++ b/python/pkgs/zope-event/default.nix
@@ -6,7 +6,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "zope-event";
   version = "5.0";
   pyproject = true;
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "zopefoundation";
     repo = "zope.event";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-85jXSrploTcskdOBI84KGGf9Bno41ZTtT/TrbgmTxiA=";
   };
 
@@ -28,10 +28,12 @@ buildPythonPackage rec {
 
   pythonNamespaces = [ "zope" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Event publishing system";
     homepage = "https://github.com/zopefoundation/zope.event";
-    changelog = "https://github.com/zopefoundation/zope.event/blob/${src.tag}/CHANGES.rst";
+    changelog = "https://github.com/zopefoundation/zope.event/blob/${finalAttrs.src.tag}/CHANGES.rst";
     license = lib.licenses.zpl21;
   };
-}
+})

--- a/python/pkgs/zope-event/default.nix
+++ b/python/pkgs/zope-event/default.nix
@@ -28,8 +28,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonNamespaces = [ "zope" ];
 
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
-
   meta = {
     description = "Event publishing system";
     homepage = "https://github.com/zopefoundation/zope.event";

--- a/python/pkgs/zstandard/default.nix
+++ b/python/pkgs/zstandard/default.nix
@@ -41,13 +41,13 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  testPaths = [ "tests" ];
+
   preCheck = ''
-    rm -r zstandard
+    rm -rf zstandard
   '';
 
   pythonImportsCheck = [ "zstandard" ];
-
-  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
 
   meta = {
     description = "Zstandard bindings for Python";

--- a/python/pkgs/zstandard/default.nix
+++ b/python/pkgs/zstandard/default.nix
@@ -9,13 +9,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "zstandard";
   version = "0.23.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-stjGLQjnJV9o96dAuuhbPJuOVGa6qcv39X8c3grGvAk=";
   };
 
@@ -47,9 +47,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "zstandard" ];
 
+  passthru.tests.unittests = finalAttrs.finalPackage.overridePythonAttrs { doCheck = true; };
+
   meta = {
     description = "Zstandard bindings for Python";
     homepage = "https://github.com/indygreg/python-zstandard";
     license = lib.licenses.bsdOriginal;
   };
-}
+})

--- a/python/python-packages-base.nix
+++ b/python/python-packages-base.nix
@@ -19,14 +19,51 @@ let
     lib.mirrorFunctionArgs f (
       origArgs:
       let
-        result = f origArgs;
+        # Build an updated argument set / fixed-point function, supporting all
+        # of: attrset origArgs, function origArgs, attrset newArgs, function
+        # newArgs.
         overrideWith =
-          newArgs: if lib.isFunction newArgs then origArgs // newArgs origArgs else origArgs // newArgs;
+          newArgs:
+          let
+            origIsFn = lib.isFunction origArgs;
+            newIsFn = lib.isFunction newArgs;
+          in
+          if origIsFn || newIsFn then
+            finalAttrs:
+            let
+              prev = if origIsFn then origArgs finalAttrs else origArgs;
+              over = if newIsFn then newArgs prev else newArgs;
+            in
+            prev // over
+          else
+            origArgs // (if newIsFn then newArgs origArgs else newArgs);
+        overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
+
+        # Make `overridePythonAttrs` available on `finalAttrs.finalPackage`
+        # (i.e. inside the package's own fixed-point) by injecting it through
+        # the user's `passthru`. The `passthru` attrs are merged into the
+        # resulting derivation by `mkDerivation`, so `result.overridePythonAttrs`
+        # is also accessible at the top level.
+        injectOverride =
+          args:
+          let
+            mergePassthru = userAttrs: {
+              passthru = (userAttrs.passthru or { }) // {
+                inherit overridePythonAttrs;
+              };
+            };
+          in
+          if lib.isFunction args then
+            finalAttrs: args finalAttrs // mergePassthru (args finalAttrs)
+          else
+            args // mergePassthru args;
+
+        result = f (injectOverride origArgs);
       in
       if lib.isAttrs result then
         result
         // {
-          overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
+          inherit overridePythonAttrs;
           overrideAttrs =
             newArgs: makeOverridablePythonPackage (args: (f args).overrideAttrs newArgs) origArgs;
         }


### PR DESCRIPTION
Defer testing to passthru, enable first class support in `buildPython{Application,Package}` to move paths to a separate output which will be used as the test suite