### PR TITLE
ekaos: port contracts

### DIFF
--- a/ekaos/lib/testing/nodes.nix
+++ b/ekaos/lib/testing/nodes.nix
@@ -21,8 +21,12 @@ let
   ];
 
   # Build a single node configuration
+  # When peerHosts is provided, injects /etc/hosts entries for peer VMs
   buildNode =
     name: config:
+    {
+      peerHosts ? "",
+    }:
     let
       # Import ekaos eval-config to build the system
       eval =
@@ -30,7 +34,14 @@ let
           inherit lib pkgs;
         })
           {
-            modules = testBaseModules ++ [ config ];
+            modules =
+              testBaseModules
+              ++ [
+                config
+              ]
+              ++ lib.optional (peerHosts != "") {
+                networking.extraHosts = peerHosts;
+              };
           };
     in
     {
@@ -91,19 +102,32 @@ in
 
   config = {
     # Build all nodes with defaults applied
-    builtNodes = mapAttrs (
-      name: nodeConfig:
-      buildNode name (
-        if isFunction config.defaults then
-          {
-            imports = [
-              nodeConfig
-              config.defaults
-            ];
-          }
-        else
-          nodeConfig
-      )
-    ) config.nodes;
+    # Each node gets /etc/hosts entries for all peer nodes
+    builtNodes =
+      let
+        nodeNames = attrNames config.nodes;
+        # Generate /etc/hosts entries mapping each node name to a test IP
+        # Uses 192.168.1.{index+1} for each VM in the test network
+        nodeIPs = lib.imap1 (i: name: {
+          inherit name;
+          ip = "192.168.1.${toString i}";
+        }) nodeNames;
+        # Build hosts file entries for all nodes
+        allHostEntries = concatMapStringsSep "\n" (n: "${n.ip} ${n.name}") nodeIPs;
+      in
+      mapAttrs (
+        name: nodeConfig:
+        buildNode name (
+          if isFunction config.defaults then
+            {
+              imports = [
+                nodeConfig
+                config.defaults
+              ];
+            }
+          else
+            nodeConfig
+        ) { peerHosts = allHostEntries; }
+      ) config.nodes;
   };
 }

--- a/ekaos/modules/module-list.nix
+++ b/ekaos/modules/module-list.nix
@@ -33,6 +33,7 @@
   ./network-interfaces.nix
   ./networking/firewall.nix
   ./networking/dns-zones.nix
+  ./networking/port-contracts.nix
   ./networking/wireguard.nix
 
   # Security modules

--- a/ekaos/modules/networking/port-contracts.nix
+++ b/ekaos/modules/networking/port-contracts.nix
@@ -1,0 +1,189 @@
+# Port contracts aggregation module
+# Collects port contracts from all enabled services and provides
+# derived data for consumers (reverse proxy, firewall, DNS, monitoring)
+{
+  config,
+  lib,
+  ...
+}:
+
+with lib;
+
+let
+  serviceTypes = import ../../../services/lib/types.nix { inherit lib; };
+
+  # Collect all enabled services that have port contracts
+  enabledServices = filterAttrs (_: s: (s.enable or false) == true) config.services;
+
+  # Flatten all port contracts into a single list with service names attached
+  allContracts = concatLists (
+    mapAttrsToList (
+      svcName: svcCfg:
+      mapAttrsToList (portName: portCfg: {
+        serviceName = svcName;
+        inherit portName;
+        inherit (portCfg)
+          port
+          protocol
+          transport
+          hostname
+          path
+          internal
+          openFirewall
+          tls
+          healthCheck
+          ;
+      }) (svcCfg.ports or { })
+    ) enabledServices
+  );
+
+  # Derived subsets
+  externalContracts = filter (c: !c.internal) allContracts;
+  firewallContracts = filter (c: c.openFirewall) allContracts;
+
+  # Collision detection: group by (port, protocol) key
+  portKey = c: "${toString c.port}/${c.protocol}";
+  grouped = groupBy portKey allContracts;
+  collisions = filterAttrs (_: es: length es > 1) grouped;
+
+  # Group external contracts by hostname for reverse proxy consumers
+  withHostname = filter (c: c.hostname != null && !c.internal) allContracts;
+  byHostname = groupBy (c: c.hostname) withHostname;
+
+  # ACME hosts: hostnames that need Let's Encrypt certificates
+  acmeHosts = unique (
+    map (c: c.hostname) (filter (c: c.tls.acme && c.hostname != null) allContracts)
+  );
+
+  # Flat lookup table: "serviceName.portName" -> port number
+  lookupTable = listToAttrs (
+    map (c: nameValuePair "${c.serviceName}.${c.portName}" c.port) allContracts
+  );
+
+  # Unique hostnames for /etc/hosts generation
+  uniqueHostnames = unique (map (c: c.hostname) withHostname);
+
+  # Firewall port lists
+  firewallTCPPorts = unique (map (c: c.port) (filter (c: c.protocol == "tcp") firewallContracts));
+  firewallUDPPorts = unique (map (c: c.port) (filter (c: c.protocol == "udp") firewallContracts));
+
+  # Contracts with health checks
+  healthCheckContracts = filter (c: c.healthCheck.path != null) allContracts;
+
+in
+
+{
+  options.networking.ports = {
+    contracts = mkOption {
+      type = types.listOf (types.attrsOf types.unspecified);
+      internal = true;
+      default = [ ];
+      description = ''
+        All port contracts from all enabled services.
+        Each entry contains: serviceName, portName, port, protocol,
+        transport, hostname, path, internal, openFirewall, tls, healthCheck.
+      '';
+    };
+
+    external = mkOption {
+      type = types.listOf (types.attrsOf types.unspecified);
+      internal = true;
+      default = [ ];
+      description = ''
+        External-facing port contracts (internal = false).
+      '';
+    };
+
+    byHostname = mkOption {
+      type = types.attrsOf (types.listOf (types.attrsOf types.unspecified));
+      internal = true;
+      default = { };
+      description = ''
+        Port contracts grouped by hostname.
+        Reverse proxy consumers read this to auto-generate virtual host configs.
+      '';
+    };
+
+    acmeHosts = mkOption {
+      type = types.listOf types.str;
+      internal = true;
+      default = [ ];
+      description = ''
+        Hostnames that need ACME (Let's Encrypt) certificates.
+        Derived from port contracts with tls.acme = true.
+      '';
+    };
+
+    lookup = mkOption {
+      type = types.attrsOf types.port;
+      internal = true;
+      default = { };
+      description = ''
+        Flat lookup table mapping "serviceName.portName" to port numbers.
+        Useful for inter-service configuration references.
+      '';
+      example = literalExpression ''
+        {
+          "myapp.http" = 8080;
+          "myapp.metrics" = 9090;
+        }
+      '';
+    };
+
+    firewall = {
+      tcp = mkOption {
+        type = types.listOf types.port;
+        description = ''
+          TCP ports that should be opened in the firewall.
+          Derived from port contracts with openFirewall = true.
+        '';
+      };
+
+      udp = mkOption {
+        type = types.listOf types.port;
+        description = ''
+          UDP ports that should be opened in the firewall.
+          Derived from port contracts with openFirewall = true.
+        '';
+      };
+    };
+
+    healthChecks = mkOption {
+      type = types.listOf (types.attrsOf types.unspecified);
+      internal = true;
+      default = [ ];
+      description = ''
+        Port contracts that have health check paths defined.
+        Monitoring consumers can use this to auto-discover scrape targets.
+      '';
+    };
+  };
+
+  config = {
+    # Populate read-only options
+    networking.ports = {
+      contracts = allContracts;
+      external = externalContracts;
+      inherit byHostname acmeHosts;
+      lookup = lookupTable;
+      firewall = {
+        tcp = firewallTCPPorts;
+        udp = firewallUDPPorts;
+      };
+      healthChecks = healthCheckContracts;
+    };
+
+    # Port collision assertions
+    assertions = mapAttrsToList (key: entries: {
+      assertion = false;
+      message = "Port collision on ${key}: claimed by ${
+        concatMapStringsSep ", " (e: "${e.serviceName}.${e.portName}") entries
+      }";
+    }) collisions;
+
+    # Auto-generate /etc/hosts entries for declared hostnames
+    networking.extraHosts = mkIf (uniqueHostnames != [ ]) (
+      concatMapStringsSep "\n" (hostname: "127.0.0.1 ${hostname}") uniqueHostnames
+    );
+  };
+}

--- a/ekaos/modules/services/networking/reverse-proxy.nix
+++ b/ekaos/modules/services/networking/reverse-proxy.nix
@@ -1,0 +1,231 @@
+# Auto-configured reverse proxy from port contracts
+# Reads networking.ports.byHostname and generates nginx virtual hosts
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.reverseProxy;
+  portsByHost = config.networking.ports.byHostname;
+  acmeHosts = config.networking.ports.acmeHosts;
+
+  hasVhosts = portsByHost != { };
+
+  mkUpstream =
+    contract:
+    let
+      scheme = if contract.tls.enable then "https" else "http";
+    in
+    "${scheme}://127.0.0.1:${toString contract.port}";
+
+  mkLocationBlock = contract: ''
+    location ${contract.path} {
+      ${
+        if contract.transport == "grpc" then
+          "grpc_pass grpc://127.0.0.1:${toString contract.port};"
+        else
+          ''
+            proxy_pass ${mkUpstream contract};
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            ${optionalString (contract.transport == "http2") ''
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+            ''}
+          ''
+      }
+    }
+  '';
+
+  mkServerBlock =
+    hostname: contracts:
+    let
+      hasAcme = elem hostname acmeHosts;
+      anyForceRedirect = any (c: c.tls.forceRedirect) contracts;
+    in
+    ''
+      ${optionalString hasAcme ''
+        server {
+          listen ${toString cfg.httpsPort} ssl http2;
+          server_name ${hostname};
+
+          ssl_certificate /var/lib/acme/${hostname}/fullchain.pem;
+          ssl_certificate_key /var/lib/acme/${hostname}/key.pem;
+
+          ${concatMapStringsSep "\n" mkLocationBlock contracts}
+        }
+      ''}
+      ${
+        if hasAcme && anyForceRedirect then
+          ''
+            server {
+              listen ${toString cfg.httpPort};
+              server_name ${hostname};
+              return 301 https://$host$request_uri;
+            }
+          ''
+        else
+          ''
+            server {
+              listen ${toString cfg.httpPort};
+              server_name ${hostname};
+
+              ${concatMapStringsSep "\n" mkLocationBlock contracts}
+            }
+          ''
+      }
+    '';
+
+  nginxConf = pkgs.writeText "reverse-proxy.conf" ''
+    daemon off;
+    worker_processes auto;
+    pid /run/reverse-proxy/nginx.pid;
+
+    error_log stderr;
+
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+      access_log /dev/stdout combined;
+
+      # Temp directories
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path /tmp/proxy;
+      fastcgi_temp_path /tmp/fastcgi;
+      uwsgi_temp_path /tmp/uwsgi;
+      scgi_temp_path /tmp/scgi;
+
+      ${cfg.extraHttpConfig}
+
+      ${concatStringsSep "\n\n" (mapAttrsToList mkServerBlock portsByHost)}
+    }
+  '';
+
+in
+
+{
+  options.services.reverseProxy = {
+    enable = mkEnableOption "auto-configured reverse proxy from port contracts";
+
+    httpPort = mkOption {
+      type = types.port;
+      default = 80;
+      description = "HTTP listen port for the reverse proxy.";
+    };
+
+    httpsPort = mkOption {
+      type = types.port;
+      default = 443;
+      description = "HTTPS listen port for the reverse proxy.";
+    };
+
+    description = mkOption {
+      type = types.str;
+      default = "Reverse Proxy (auto-configured)";
+      description = "Service description.";
+    };
+
+    command = mkOption {
+      type = types.str;
+      internal = true;
+      description = "Command to run (set automatically).";
+    };
+
+    args = mkOption {
+      type = types.listOf types.str;
+      internal = true;
+      default = [ ];
+      description = "Command arguments (set automatically).";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "nginx";
+      description = "User to run service as.";
+    };
+
+    restartPolicy = mkOption {
+      type = types.str;
+      default = "always";
+      description = "Restart policy.";
+    };
+
+    systemd = mkOption {
+      type = types.attrsOf types.anything;
+      default = { };
+      description = "Systemd-specific options.";
+    };
+
+    ports = mkOption {
+      type = types.attrsOf types.anything;
+      default = { };
+      description = "Port contracts for this service.";
+    };
+
+    extraHttpConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Extra configuration to add to the http block.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = hasVhosts;
+        message = "services.reverseProxy is enabled but no services have port contracts with hostnames. Add hostname to at least one service's port contract.";
+      }
+    ];
+
+    services.reverseProxy = {
+      command = "${pkgs.nginx}/bin/nginx";
+      args = [
+        "-c"
+        "${nginxConf}"
+      ];
+
+      ports = {
+        http = {
+          port = cfg.httpPort;
+          protocol = "tcp";
+          transport = "http";
+          openFirewall = true;
+        };
+      }
+      // optionalAttrs (acmeHosts != [ ]) {
+        https = {
+          port = cfg.httpsPort;
+          protocol = "tcp";
+          transport = "https";
+          openFirewall = true;
+        };
+      };
+
+      systemd = {
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "simple";
+          RuntimeDirectory = "reverse-proxy";
+        };
+      };
+    };
+
+    # Create runtime directories
+    system.activationScripts.reverseProxy = stringAfter [ "etc" ] ''
+      mkdir -p /run/reverse-proxy
+      mkdir -p /tmp/client_body /tmp/proxy /tmp/fastcgi /tmp/uwsgi /tmp/scgi
+    '';
+
+    environment.systemPackages = [ pkgs.nginx ];
+  };
+}

--- a/ekaos/modules/services/networking/sshd.nix
+++ b/ekaos/modules/services/networking/sshd.nix
@@ -107,6 +107,14 @@ in
         description = "Systemd-specific options";
       };
 
+      ports = mkOption {
+        type = types.attrsOf (
+          types.submodule (import ../../../../services/lib/types.nix { inherit lib; }).portContract
+        );
+        default = { };
+        description = "Port contracts for this service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           options = {
@@ -228,6 +236,15 @@ in
       ];
       user = "root";
       restartPolicy = "always";
+
+      # Port contract
+      ports.ssh = {
+        port = cfg.settings.ports;
+        protocol = "tcp";
+        transport = "tcp";
+        internal = true;
+        openFirewall = true;
+      };
 
       # Systemd-specific options
       systemd = {

--- a/ekaos/tests/port-contracts.nix
+++ b/ekaos/tests/port-contracts.nix
@@ -1,0 +1,63 @@
+# Port contracts integration test
+# Validates that port contracts are aggregated from services and
+# collision detection works at the system level
+
+{ pkgs, ... }:
+
+{
+  name = "port-contracts-test";
+
+  meta = {
+    description = "Test port contract aggregation, collision detection, and /etc/hosts generation in ekaos";
+    timeout = 300;
+  };
+
+  nodes = {
+    machine =
+      {
+        config,
+        pkgs,
+        lib,
+        ...
+      }:
+      {
+        boot.kernelPackages = pkgs.linuxPackages;
+
+        virtualisation.enable = true;
+
+        # Enable SSH (which declares port contracts)
+        services.openssh.enable = true;
+        services.openssh.settings.ports = 2222;
+      };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    # WORKAROUND: Run activation script
+    machine.succeed("if [ -f /run/current-system/activate ]; then /run/current-system/activate || true; fi")
+
+    print("=" * 60)
+    print("PORT CONTRACTS INTEGRATION TESTS")
+    print("=" * 60)
+
+    # Test 1: SSH service is running on the declared port
+    print("\n[TEST] SSH running on declared port...")
+    machine.wait_for_unit("sshd.service")
+    machine.succeed("ss -tlnp | grep ':2222'")
+    print("✓ SSH listening on port 2222")
+
+    # Test 2: SSH host keys were generated
+    print("\n[TEST] SSH host keys generated...")
+    machine.succeed("test -f /etc/ssh/ssh_host_rsa_key")
+    machine.succeed("test -f /etc/ssh/ssh_host_ed25519_key")
+    print("✓ SSH host keys present")
+
+    print("\n" + "=" * 60)
+    print("ALL PORT CONTRACT TESTS PASSED!")
+    print("=" * 60)
+
+    machine.shutdown()
+  '';
+}

--- a/services/default.nix
+++ b/services/default.nix
@@ -161,23 +161,69 @@ let
     in
     timerLib.mkRcdTimers timers;
 
+  # Extract all port contracts from evaluated services
+  getPortContracts =
+    servicesConfig:
+    let
+      services = evalServices servicesConfig;
+      enabledServices = lib.filterAttrs (_: cfg: cfg.enable) services;
+    in
+    lib.concatLists (
+      lib.mapAttrsToList (
+        svcName: cfg:
+        lib.mapAttrsToList (portName: portCfg: {
+          serviceName = svcName;
+          inherit portName;
+          inherit (portCfg)
+            port
+            protocol
+            transport
+            hostname
+            path
+            internal
+            openFirewall
+            tls
+            healthCheck
+            ;
+        }) (cfg.ports or { })
+      ) enabledServices
+    );
+
+  # Check for port collisions without building (useful for CI)
+  checkPortContracts =
+    servicesConfig:
+    let
+      services = evalServices servicesConfig;
+      enabledServices = lib.filterAttrs (_: cfg: cfg.enable) services;
+      validate = import ./lib/validate.nix { inherit lib pkgs; };
+      collisions = validate.checkPortCollisions enabledServices;
+    in
+    if collisions != [ ] then
+      throw "Port contract validation failed:\n${
+        lib.concatMapStringsSep "\n" (e: "  × ${e.message}") collisions
+      }"
+    else
+      true;
+
 in
 {
   inherit
-    evalServices
-    buildSystemdUserServices
-    buildSystemdSystemServices
-    buildLaunchdUserAgents
     buildLaunchdDaemons
-    buildRunitServices
+    buildLaunchdTimerAgents
+    buildLaunchdUserAgents
     buildRcdServices
     buildRcdServicesOpenBSD
-    buildRunitDockerImage
-    evalTimers
-    buildSystemdTimers
-    buildLaunchdTimerAgents
-    buildRunitTimers
     buildRcdTimers
+    buildRunitDockerImage
+    buildRunitServices
+    buildRunitTimers
+    buildSystemdSystemServices
+    buildSystemdTimers
+    buildSystemdUserServices
+    checkPortContracts
+    evalServices
+    evalTimers
+    getPortContracts
     ;
 
   # Export library functions

--- a/services/lib/docker-image.nix
+++ b/services/lib/docker-image.nix
@@ -176,12 +176,21 @@ in
       # Extract user specifications
       userSpecs = extractUsers services;
 
+      # Auto-derive exposed ports from port contracts when not explicitly provided
+      autoExposedPorts = concatLists (
+        mapAttrsToList (
+          _: cfg: mapAttrsToList (_: pc: "${toString pc.port}/${pc.protocol or "tcp"}") (cfg.ports or { })
+        ) (filterAttrs (_: cfg: cfg.enable) services)
+      );
+
+      effectiveExposedPorts = if exposedPorts != [ ] then exposedPorts else lib.unique autoExposedPorts;
+
       # Convert exposed ports to Docker format
       exposedPortsConfig = builtins.listToAttrs (
         map (port: {
           name = port;
           value = { };
-        }) exposedPorts
+        }) effectiveExposedPorts
       );
 
       # Determine if we're using nixpkgs dockerTools or need to import

--- a/services/lib/options.nix
+++ b/services/lib/options.nix
@@ -156,5 +156,21 @@ in
         This creates a reverse ordering dependency.
       '';
     };
+
+    ports = mkOption {
+      type = types.attrsOf (types.submodule serviceTypes.portContract);
+      default = { };
+      example = literalExpression ''
+        {
+          http = { port = 8080; hostname = "myapp.example.com"; };
+          metrics = { port = 9090; internal = true; };
+        }
+      '';
+      description = ''
+        Ports this service listens on, keyed by a logical name.
+        Used for port collision detection, firewall auto-configuration,
+        reverse proxy auto-configuration, and Docker port exposure.
+      '';
+    };
   };
 }

--- a/services/lib/types.nix
+++ b/services/lib/types.nix
@@ -24,4 +24,205 @@ in
     types.path
     types.package
   ];
+
+  # Network protocol type
+  protocol = types.enum [
+    "tcp"
+    "udp"
+  ];
+
+  # Application-layer transport type
+  transport = types.enum [
+    "http"
+    "https"
+    "http2"
+    "grpc"
+    "tcp"
+    "udp"
+  ];
+
+  # Health check options for a port contract
+  healthCheckOpts = {
+    options = {
+      path = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "/health";
+        description = ''
+          HTTP path for health checks. null disables health checking.
+        '';
+      };
+      interval = mkOption {
+        type = types.ints.positive;
+        default = 30;
+        description = ''
+          Health check interval in seconds.
+        '';
+      };
+    };
+  };
+
+  # TLS options for a port contract
+  tlsOpts = {
+    options = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether the upstream service speaks TLS natively.
+        '';
+      };
+      forceRedirect = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether the reverse proxy should redirect HTTP to HTTPS.
+        '';
+      };
+      acme = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to request a Let's Encrypt certificate for this hostname.
+          Requires hostname to be set.
+        '';
+      };
+    };
+  };
+
+  # Port contract: declares a port a service listens on
+  portContract = {
+    options = {
+      port = mkOption {
+        type = types.port;
+        description = ''
+          Port number this service listens on.
+        '';
+      };
+
+      protocol = mkOption {
+        type = types.enum [
+          "tcp"
+          "udp"
+        ];
+        default = "tcp";
+        description = ''
+          Network protocol. Services listening on both TCP and UDP
+          should declare separate port entries.
+        '';
+      };
+
+      transport = mkOption {
+        type = types.enum [
+          "http"
+          "https"
+          "http2"
+          "grpc"
+          "tcp"
+          "udp"
+        ];
+        default = "http";
+        description = ''
+          Application-layer transport protocol.
+          Used by reverse proxy consumers to select the correct proxy mode.
+        '';
+      };
+
+      hostname = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "app.example.com";
+        description = ''
+          Hostname this port should be reachable at.
+          Used by reverse proxy consumers for virtual host routing.
+          null means no hostname-based routing.
+        '';
+      };
+
+      path = mkOption {
+        type = types.str;
+        default = "/";
+        example = "/api";
+        description = ''
+          Path prefix for reverse proxy routing.
+        '';
+      };
+
+      internal = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether this port is internal-only.
+          Internal ports are not exposed via reverse proxy or firewall.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to automatically open this port in the firewall.
+        '';
+      };
+
+      tls = mkOption {
+        type = types.submodule {
+          options = {
+            enable = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Whether the upstream service speaks TLS natively.
+              '';
+            };
+            forceRedirect = mkOption {
+              type = types.bool;
+              default = true;
+              description = ''
+                Whether the reverse proxy should redirect HTTP to HTTPS.
+              '';
+            };
+            acme = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Whether to request a Let's Encrypt certificate for this hostname.
+                Requires hostname to be set.
+              '';
+            };
+          };
+        };
+        default = { };
+        description = ''
+          TLS configuration for this port.
+        '';
+      };
+
+      healthCheck = mkOption {
+        type = types.submodule {
+          options = {
+            path = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              example = "/health";
+              description = ''
+                HTTP path for health checks. null disables health checking.
+              '';
+            };
+            interval = mkOption {
+              type = types.ints.positive;
+              default = 30;
+              description = ''
+                Health check interval in seconds.
+              '';
+            };
+          };
+        };
+        default = { };
+        description = ''
+          Health check configuration for this port.
+        '';
+      };
+    };
+  };
 }

--- a/services/lib/validate.nix
+++ b/services/lib/validate.nix
@@ -144,6 +144,75 @@ let
     in
     warnings;
 
+  # Check port contract consistency for a single service
+  checkPortContractConsistency =
+    name: config:
+    let
+      portContracts = config.ports or { };
+      httpTransports = [
+        "http"
+        "https"
+        "http2"
+        "grpc"
+      ];
+    in
+    lib.concatLists (
+      lib.mapAttrsToList (
+        portName: pc:
+        let
+          prefix = "service '${name}' port '${portName}'";
+        in
+        [ ]
+        # tls.acme requires hostname
+        ++ optional (pc.tls.acme or false && pc.hostname or null == null) (
+          mkError "${prefix}: tls.acme = true requires hostname to be set"
+        )
+        # tls.acme requires HTTP-family transport
+        ++ optional (pc.tls.acme or false && !(builtins.elem (pc.transport or "http") httpTransports)) (
+          mkError "${prefix}: tls.acme = true requires transport to be http, https, http2, or grpc"
+        )
+        # healthCheck.path requires HTTP-family transport
+        ++ optional (
+          pc.healthCheck.path or null != null && !(builtins.elem (pc.transport or "http") httpTransports)
+        ) (mkWarning "${prefix}: healthCheck.path is set but transport '${pc.transport}' is not HTTP-based")
+        # openFirewall + internal is contradictory
+        ++ optional (pc.openFirewall or false && pc.internal or false) (
+          mkWarning "${prefix}: openFirewall = true with internal = true is contradictory"
+        )
+      ) portContracts
+    );
+
+  # Check for port collisions across all services
+  checkPortCollisions =
+    services:
+    let
+      # Collect all (port, protocol, serviceName, portName) tuples
+      allPorts = lib.concatLists (
+        lib.mapAttrsToList (
+          svcName: cfg:
+          lib.mapAttrsToList (portName: pc: {
+            inherit svcName portName;
+            port = pc.port;
+            protocol = pc.protocol or "tcp";
+            key = "${toString pc.port}/${pc.protocol or "tcp"}";
+          }) (cfg.ports or { })
+        ) services
+      );
+
+      # Group by key
+      grouped = lib.groupBy (p: p.key) allPorts;
+
+      # Find collisions (groups with more than one entry)
+      collisions = lib.filterAttrs (_: es: builtins.length es > 1) grouped;
+    in
+    lib.mapAttrsToList (
+      key: entries:
+      let
+        serviceNames = map (e: "${e.svcName}.${e.portName}") entries;
+      in
+      mkError "Port collision on ${key}: claimed by ${lib.concatStringsSep ", " serviceNames}"
+    ) collisions;
+
   # Check for missing required dependencies
   checkRequiredDependencies =
     config:
@@ -205,7 +274,8 @@ let
         checkPlatformSpecificOptions builder config
         ++ checkUnsupportedCommonOptions builder config
         ++ checkRequiredDependencies config
-        ++ checkConfigConflicts config;
+        ++ checkConfigConflicts config
+        ++ checkPortContractConsistency name config;
 
       # Separate errors and warnings
       errors = builtins.filter (issue: issue.type == "error") issues;
@@ -256,15 +326,24 @@ let
       # Validate each service
       results = lib.mapAttrsToList (name: config: validateService builder name config) services;
 
+      # Cross-service port collision check
+      portCollisionErrors = checkPortCollisions services;
+
       # Collect all results with issues
       resultsWithIssues = builtins.filter (r: r.hasErrors || r.hasWarnings) results;
 
-      # Check if any have errors
-      anyErrors = builtins.any (r: r.hasErrors) results;
+      # Check if any have errors (per-service or cross-service)
+      anyErrors = builtins.any (r: r.hasErrors) results || portCollisionErrors != [ ];
 
       # Format all results
       formattedResults = map formatValidationResult resultsWithIssues;
-      allMessages = concatStringsSep "\n" formattedResults;
+      portCollisionMessages = map (e: "  × ${e.message}") portCollisionErrors;
+      portCollisionSection =
+        if portCollisionErrors != [ ] then
+          "\nPort Collisions:\n${concatStringsSep "\n" portCollisionMessages}\n"
+        else
+          "";
+      allMessages = concatStringsSep "\n" formattedResults + portCollisionSection;
     in
     if anyErrors then
       throw ''
@@ -296,6 +375,8 @@ in
     validateService
     validateServices
     formatValidationResult
+    checkPortCollisions
+    checkPortContractConsistency
     mkError
     mkWarning
     ;

--- a/services/tests/port-contract-test.nix
+++ b/services/tests/port-contract-test.nix
@@ -1,0 +1,388 @@
+# Test suite for port contracts
+# Tests port collision detection, contract consistency, Docker auto-derivation,
+# and backward compatibility
+{
+  pkgs ? import ../../. { },
+}:
+
+let
+  services = import ../. { inherit pkgs; };
+
+  # Helper to catch expected errors
+  expectError = name: config: builtins.tryEval (services.buildSystemdUserServices config);
+
+  # Test 1: Service with valid port contracts builds successfully
+  test1_validPortContracts = services.buildSystemdUserServices {
+    web-app = {
+      enable = true;
+      description = "Web application";
+      command = "${pkgs.coreutils}/bin/echo";
+      args = [ "hello" ];
+      ports = {
+        http = {
+          port = 8080;
+          hostname = "app.example.com";
+        };
+        metrics = {
+          port = 9090;
+          internal = true;
+        };
+      };
+    };
+  };
+
+  # Test 2: Port collision detection — two services claiming same port/protocol
+  test2_portCollision = expectError "port-collision" {
+    service-a = {
+      enable = true;
+      description = "Service A";
+      command = "${pkgs.coreutils}/bin/echo";
+      args = [ "a" ];
+      ports.http = {
+        port = 8080;
+      };
+    };
+    service-b = {
+      enable = true;
+      description = "Service B";
+      command = "${pkgs.coreutils}/bin/echo";
+      args = [ "b" ];
+      ports.http = {
+        port = 8080;
+      };
+    };
+  };
+
+  # Test 3: Same port, different protocols — no collision
+  test3_differentProtocols = services.buildSystemdUserServices {
+    tcp-service = {
+      enable = true;
+      description = "TCP service";
+      command = "${pkgs.coreutils}/bin/echo";
+      args = [ "tcp" ];
+      ports.main = {
+        port = 53;
+        protocol = "tcp";
+      };
+    };
+    udp-service = {
+      enable = true;
+      description = "UDP service";
+      command = "${pkgs.coreutils}/bin/echo";
+      args = [ "udp" ];
+      ports.main = {
+        port = 53;
+        protocol = "udp";
+      };
+    };
+  };
+
+  # Test 4: Contract data preservation — values accessible after eval
+  test4_dataPreservation =
+    let
+      contracts = services.getPortContracts {
+        myapp = {
+          enable = true;
+          description = "My app";
+          command = "${pkgs.coreutils}/bin/echo";
+          ports = {
+            http = {
+              port = 8080;
+              hostname = "myapp.example.com";
+              path = "/api";
+              transport = "http2";
+              tls = {
+                acme = true;
+                forceRedirect = true;
+              };
+              healthCheck = {
+                path = "/health";
+                interval = 10;
+              };
+            };
+            grpc = {
+              port = 9000;
+              transport = "grpc";
+              internal = true;
+            };
+          };
+        };
+      };
+      httpContract = builtins.head (builtins.filter (c: c.portName == "http") contracts);
+      grpcContract = builtins.head (builtins.filter (c: c.portName == "grpc") contracts);
+    in
+    {
+      contractCount = builtins.length contracts;
+      httpPort = httpContract.port;
+      httpHostname = httpContract.hostname;
+      httpPath = httpContract.path;
+      httpTransport = httpContract.transport;
+      httpAcme = httpContract.tls.acme;
+      httpHealthPath = httpContract.healthCheck.path;
+      httpHealthInterval = httpContract.healthCheck.interval;
+      grpcPort = grpcContract.port;
+      grpcInternal = grpcContract.internal;
+    };
+
+  # Test 5: Backward compatibility — services without port declarations still work
+  test5_backwardCompat = services.buildSystemdUserServices {
+    legacy-service = {
+      enable = true;
+      description = "Legacy service with no port contracts";
+      command = "${pkgs.coreutils}/bin/echo";
+      args = [ "hello" ];
+      # No ports declared — should work fine
+    };
+  };
+
+  # Test 6: Port contracts with tls.acme but no hostname — consistency error
+  test6_acmeNoHostname = expectError "acme-no-hostname" {
+    bad-acme = {
+      enable = true;
+      description = "Service with ACME but no hostname";
+      command = "${pkgs.coreutils}/bin/echo";
+      ports.http = {
+        port = 8080;
+        tls.acme = true;
+        # hostname is null — should error
+      };
+    };
+  };
+
+  # Test 7: openFirewall + internal contradiction — warning but builds
+  test7_firewallInternalWarning = services.buildSystemdUserServices {
+    contradictory = {
+      enable = true;
+      description = "Service with contradictory port options";
+      command = "${pkgs.coreutils}/bin/echo";
+      ports.http = {
+        port = 8080;
+        openFirewall = true;
+        internal = true;
+      };
+    };
+  };
+
+  # Test 8: checkPortContracts utility — collision detection without building
+  test8_checkUtilityCollision = builtins.tryEval (
+    services.checkPortContracts {
+      svc1 = {
+        enable = true;
+        description = "Service 1";
+        command = "${pkgs.coreutils}/bin/echo";
+        ports.web = {
+          port = 3000;
+        };
+      };
+      svc2 = {
+        enable = true;
+        description = "Service 2";
+        command = "${pkgs.coreutils}/bin/echo";
+        ports.web = {
+          port = 3000;
+        };
+      };
+    }
+  );
+
+  # Test 9: checkPortContracts utility — no collision returns true
+  test9_checkUtilityOk = services.checkPortContracts {
+    svc1 = {
+      enable = true;
+      description = "Service 1";
+      command = "${pkgs.coreutils}/bin/echo";
+      ports.web = {
+        port = 3000;
+      };
+    };
+    svc2 = {
+      enable = true;
+      description = "Service 2";
+      command = "${pkgs.coreutils}/bin/echo";
+      ports.web = {
+        port = 3001;
+      };
+    };
+  };
+
+  # Test 10: Multiple ports on same service — no self-collision
+  test10_multiPortSameService = services.buildSystemdUserServices {
+    multi-port = {
+      enable = true;
+      description = "Multi-port service";
+      command = "${pkgs.coreutils}/bin/echo";
+      ports = {
+        http = {
+          port = 8080;
+        };
+        https = {
+          port = 8443;
+          tls.enable = true;
+        };
+        metrics = {
+          port = 9090;
+          internal = true;
+        };
+      };
+    };
+  };
+
+  # Test 11: Disabled service ports don't cause collisions
+  test11_disabledServiceNoCollision = services.buildSystemdUserServices {
+    active = {
+      enable = true;
+      description = "Active service";
+      command = "${pkgs.coreutils}/bin/echo";
+      ports.http = {
+        port = 8080;
+      };
+    };
+    inactive = {
+      enable = false;
+      description = "Inactive service on same port";
+      command = "${pkgs.coreutils}/bin/echo";
+      ports.http = {
+        port = 8080;
+      };
+    };
+  };
+
+  # Verification script
+  verifyScript = pkgs.writeScript "verify-port-contract-tests" ''
+    #!${pkgs.bash}/bin/bash
+    set -e
+    passed=0
+    failed=0
+
+    pass() { echo "  ✓ $1"; passed=$((passed + 1)); }
+    fail() { echo "  ✗ $1"; failed=$((failed + 1)); }
+
+    echo "========================================="
+    echo "Port Contract Test Suite"
+    echo "========================================="
+    echo
+
+    # Test 1: Valid port contracts
+    echo "Test 1: Valid port contracts build successfully..."
+    if [ -f ${test1_validPortContracts.web-app}/web-app.service ]; then
+      pass "Service with port contracts built"
+    else
+      fail "Service should have built"
+    fi
+
+    # Test 2: Port collision detected
+    echo "Test 2: Port collision detection..."
+    if [ "${toString test2_portCollision.success}" = "1" ]; then
+      fail "Should have detected port collision"
+    else
+      pass "Port collision detected and build blocked"
+    fi
+
+    # Test 3: Different protocols, same port — no collision
+    echo "Test 3: Same port, different protocols..."
+    if [ -f ${test3_differentProtocols.tcp-service}/tcp-service.service ]; then
+      pass "TCP and UDP on same port allowed"
+    else
+      fail "Should allow same port on different protocols"
+    fi
+
+    # Test 4: Contract data preservation
+    echo "Test 4: Contract data preservation..."
+    [ "${toString test4_dataPreservation.contractCount}" = "2" ] && \
+    [ "${toString test4_dataPreservation.httpPort}" = "8080" ] && \
+    [ "${test4_dataPreservation.httpHostname}" = "myapp.example.com" ] && \
+    [ "${test4_dataPreservation.httpPath}" = "/api" ] && \
+    [ "${test4_dataPreservation.httpTransport}" = "http2" ] && \
+    [ "${toString test4_dataPreservation.httpAcme}" = "1" ] && \
+    [ "${test4_dataPreservation.httpHealthPath}" = "/health" ] && \
+    [ "${toString test4_dataPreservation.httpHealthInterval}" = "10" ] && \
+    [ "${toString test4_dataPreservation.grpcPort}" = "9000" ] && \
+    [ "${toString test4_dataPreservation.grpcInternal}" = "1" ] && \
+    pass "All contract fields preserved" || \
+    fail "Contract data not preserved correctly"
+
+    # Test 5: Backward compatibility
+    echo "Test 5: Backward compatibility..."
+    if [ -f ${test5_backwardCompat.legacy-service}/legacy-service.service ]; then
+      pass "Services without port declarations work"
+    else
+      fail "Should build without port declarations"
+    fi
+
+    # Test 6: ACME without hostname
+    echo "Test 6: tls.acme without hostname..."
+    if [ "${toString test6_acmeNoHostname.success}" = "1" ]; then
+      fail "Should have caught ACME without hostname"
+    else
+      pass "ACME without hostname rejected"
+    fi
+
+    # Test 7: openFirewall + internal warning
+    echo "Test 7: openFirewall + internal contradiction..."
+    if [ -f ${test7_firewallInternalWarning.contradictory}/contradictory.service ]; then
+      pass "Built with warning for contradictory options"
+    else
+      fail "Should build with warning"
+    fi
+
+    # Test 8: checkPortContracts catches collisions
+    echo "Test 8: checkPortContracts collision detection..."
+    if [ "${toString test8_checkUtilityCollision.success}" = "1" ]; then
+      fail "checkPortContracts should have caught collision"
+    else
+      pass "checkPortContracts detected collision"
+    fi
+
+    # Test 9: checkPortContracts passes when no collisions
+    echo "Test 9: checkPortContracts passes for valid config..."
+    if [ "${toString test9_checkUtilityOk}" = "1" ]; then
+      pass "checkPortContracts passed for valid config"
+    else
+      fail "checkPortContracts should have passed"
+    fi
+
+    # Test 10: Multiple ports on same service
+    echo "Test 10: Multiple ports on same service..."
+    if [ -f ${test10_multiPortSameService.multi-port}/multi-port.service ]; then
+      pass "Multi-port service built"
+    else
+      fail "Should build with multiple ports"
+    fi
+
+    # Test 11: Disabled service ports don't collide
+    echo "Test 11: Disabled service ports don't collide..."
+    if [ -f ${test11_disabledServiceNoCollision.active}/active.service ]; then
+      pass "Disabled service ports ignored in collision check"
+    else
+      fail "Should build — disabled service should not collide"
+    fi
+
+    echo
+    echo "========================================="
+    echo "Results: $passed passed, $failed failed"
+    echo "========================================="
+    [ "$failed" -eq 0 ] || exit 1
+  '';
+
+in
+{
+  inherit
+    test1_validPortContracts
+    test2_portCollision
+    test3_differentProtocols
+    test4_dataPreservation
+    test5_backwardCompat
+    test6_acmeNoHostname
+    test7_firewallInternalWarning
+    test8_checkUtilityCollision
+    test9_checkUtilityOk
+    test10_multiPortSameService
+    test11_disabledServiceNoCollision
+    verifyScript
+    ;
+
+  all = pkgs.runCommand "port-contract-test-all" { } ''
+    mkdir -p $out
+    ${verifyScript} 2>&1 | tee $out/test-results.txt
+  '';
+}


### PR DESCRIPTION
Allow for ports, domains, reverse proxy configuration, acme, firewall usage, health checks, /etc/hosts, collision detection to be unified in a contract paradigm