### PR TITLE
rPackages: add R package scope with overlays.r support

### DIFF
--- a/config/overlays.nix
+++ b/config/overlays.nix
@@ -39,5 +39,13 @@ in
         Overlays to be applied to each haskell package set.
       '';
     };
+
+    overlays.r = mkOption {
+      type = types.listOf overlayType;
+      default = [ ];
+      description = ''
+        Overlays to be applied to the R package set.
+      '';
+    };
   };
 }

--- a/r/default.nix
+++ b/r/default.nix
@@ -1,0 +1,27 @@
+# R package scope.
+#
+# Downstream repos (r-packages) inject packages via config.overlays.r.
+# Uses makeScope so auto-called packages resolve R deps from this scope
+# and fall back to pkgs for system dependencies (fetchurl, zlib, etc.).
+
+{
+  lib,
+  pkgs,
+  config,
+  buildRPackage,
+}:
+
+let
+  inherit (lib) makeScope composeManyExtensions extends;
+
+  basePackages = self: {
+    inherit buildRPackage;
+    # Expose pkgs so config.overlays.r extensions can access system deps
+    # (e.g. pkgs.curl.dev) without shadowing from R package names.
+    inherit pkgs;
+  };
+
+  extensions = composeManyExtensions config.overlays.r;
+
+in
+makeScope pkgs.newScope (extends extensions basePackages)

--- a/top-level.nix
+++ b/top-level.nix
@@ -814,6 +814,8 @@ with final;
 
   buildRPackage = callPackage ./build-support/r { };
 
+  rPackages = callPackage ./r { inherit config; };
+
   buildMavenPackage = java.buildMavenPackage;
   buildGradlePackage = java.buildGradlePackage;
   buildNpmPackage = nodejs.buildNpmPackage;


### PR DESCRIPTION
Add overlays.r config option and rPackages scope using makeScope, matching the existing pattern for python and haskell overlays. Downstream repos (r-packages) inject packages via config.overlays.r.