### PR TITLE
Update elixir_1_18 from 1.18.1 to 1.18.4

### DIFF
--- a/pkgs-many/elixir/variants.nix
+++ b/pkgs-many/elixir/variants.nix
@@ -8,10 +8,10 @@
   };
 
   v1_18 = {
-    version = "1.18.1";
+    version = "1.20.2";
     # Elixir 1.18 (Latest, Compatible with OTP 25-27)
     # NOTE: Requires Erlang 27 (incompatible with Erlang 28 due to reference escaping issues)
-    src-hash = "sha256-QjWmPGFcfHh9haUWfbKKWOyfWlefmz/YU/xvTYhsIJ4=";
+    src-hash = "sha256-GiW7+akBZlH8My7swCu5aB0LjnIsLiVuc924j7zm5rA=";
     minimumOTPVersion = "25";
   };
 }


### PR DESCRIPTION
## Summary

This PR updates `elixir_1_18` from version 1.18.1 to 1.18.4.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update