### PR TITLE
Update kotlinc from 2.4.0 to 2.4.10

### DIFF
--- a/pkgs-many/kotlin/variants.nix
+++ b/pkgs-many/kotlin/variants.nix
@@ -1,7 +1,7 @@
 {
   v2_1 = {
-    version = "2.4.0";
+    version = "2.4.10";
     # Kotlin 2.1 (Latest stable with K2 compiler)
-    src-hash = "sha256-uhuebrbdwydQeSJPLp6korAu731Zzi04QE8EsiYTwgo=";
+    src-hash = "sha256-Rz3WbHo+9LGCBls9pnBGbBvydzqduw7Yszo5/p1Ph20=";
   };
 }


### PR DESCRIPTION
## Summary

This PR updates `kotlinc` from version 2.4.0 to 2.4.10.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update