### PR TITLE
Update python313Packages.anyio from 4.14.1 to 4.14.2

### DIFF
--- a/python/pkgs/anyio/default.nix
+++ b/python/pkgs/anyio/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "anyio";
-  version = "4.14.1";
+  version = "4.14.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "agronholm";
     repo = "anyio";
     tag = version;
-    hash = "sha256-LPNRNb1RuSVQqsI6aAAiYWC2c2CZAhFS67XW9OfbIiE=";
+    hash = "sha256-MEU0c8/NI1vlyNtBsg/hGLv6DR619ZqoZzNY1eJLEWM=";
   };
 
   build-system = [ setuptools-scm ];


### PR DESCRIPTION
## Summary

This PR updates `python313Packages.anyio` from version 4.14.1 to 4.14.2.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update