### PR TITLE
Update python313Packages.jaraco-functools from 4.5.0 to 4.6.0

### DIFF
--- a/python/pkgs/jaraco-functools/default.nix
+++ b/python/pkgs/jaraco-functools/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "jaraco-functools";
-  version = "4.5.0";
+  version = "4.6.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "jaraco_functools";
     inherit (finalAttrs) version;
-    hash = "sha256-O7VmXqSgIM94pwQOiRVMd+2ts8p082ZHlmnFmZqnCwM=";
+    hash = "sha256-iAxXfslyCzoFLVvGEfufImmz2HkC70JEDfRDuI5EMoA=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Summary

This PR updates `python313Packages.jaraco-functools` from version 4.5.0 to 4.6.0.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update