### PR TITLE
Update python313Packages.pbs-installer from 2026.06.10 to 2026.07.18

### DIFF
--- a/python/pkgs/pbs-installer/default.nix
+++ b/python/pkgs/pbs-installer/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "pbs-installer";
-  version = "2026.06.10";
+  version = "2026.07.18";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "frostming";
     repo = "pbs-installer";
     tag = version;
-    hash = "sha256-1hMc6ogMXuTmxaTYmVERhjM9XBp+FgWRqv476vi1pyQ=";
+    hash = "sha256-7DZdaxpXAyG3hqZvgR0aHXv5M1XKRZ129hrL9wYpySs=";
   };
 
   build-system = [ pdm-backend ];


### PR DESCRIPTION
## Summary

This PR updates `python313Packages.pbs-installer` from version 2026.06.10 to 2026.07.18.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update