### PR TITLE
Update python313Packages.platformdirs from 4.10.0 to 4.11.0

### DIFF
--- a/python/pkgs/platformdirs/default.nix
+++ b/python/pkgs/platformdirs/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "platformdirs";
-  version = "4.10.0";
+  version = "4.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tox-dev";
     repo = "platformdirs";
     tag = version;
-    hash = "sha256-Sx5ln2mF2FkChP3UKu+GmOIIV8DNoJyYgsNiVDkVqQE=";
+    hash = "sha256-ytl0q3PhjdLIo6RP2+DlekSWn0genM4HJMdCSfnnaqg=";
   };
 
   build-system = [


### PR DESCRIPTION
## Summary

This PR updates `python313Packages.platformdirs` from version 4.10.0 to 4.11.0.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update