### PR TITLE
Update python313Packages.pip-tools from 7.5.3 to 7.6.0

### DIFF
--- a/python/pkgs/pip-tools/default.nix
+++ b/python/pkgs/pip-tools/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "pip-tools";
-  version = "7.5.3";
+  version = "7.6.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "jazzband";
     repo = "pip-tools";
     tag = "v${version}";
-    hash = "sha256-MkYGD/ropw+MLLrk4gRZZguOv5extzNNXwTy6NQnCu0=";
+    hash = "sha256-ggj8wdwF3lpsuMqp0spgbqVfGI3cZc+ms4SG0XAXCB4=";
   };
 
   patches = [


### PR DESCRIPTION
## Summary

This PR updates `python313Packages.pip-tools` from version 7.5.3 to 7.6.0.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update