### PR TITLE
Update python313Packages.scikit-build-core from 1.0.2 to 1.0.3

### DIFF
--- a/python/pkgs/scikit-build-core/default.nix
+++ b/python/pkgs/scikit-build-core/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "scikit-build-core";
-  version = "1.0.2";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scikit-build";
     repo = "scikit-build-core";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-skqX3+jS+lT0zfc5E4ssrZfoZkUrel9WD6a70OX1shg=";
+    hash = "sha256-pEBdDXmg9wSrOBRTiUrVqdAcN5WEdHPIcGhpm3ze130=";
   };
 
   postPatch = lib.optionalString (pythonOlder "3.11") ''


### PR DESCRIPTION
## Summary

This PR updates `python313Packages.scikit-build-core` from version 1.0.2 to 1.0.3.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update