### PR TITLE
Update python313Packages.gevent from 26.5.0 to 26.7.0

### DIFF
--- a/python/pkgs/gevent/default.nix
+++ b/python/pkgs/gevent/default.nix
@@ -24,12 +24,12 @@
 
 buildPythonPackage rec {
   pname = "gevent";
-  version = "26.5.0";
+  version = "26.7.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-FlXrBMHiDXGyqko8dSgWLdWP9sxGoDevHwH1NMgP77o=";
+    hash = "sha256-WzM6VW44owKxuMgFJb7xbUN+FvHndnlHeJQGhBhWoQI=";
   };
 
   build-system = [


### PR DESCRIPTION
## Summary

This PR updates `python313Packages.gevent` from version 26.5.0 to 26.7.0.

## Changes

- Updated package version
- Updated source hash

🤖 Generated with ekapkgs-update