### PR TITLE
Includes output as default for headers

### DIFF
--- a/ci/packages.nix
+++ b/ci/packages.nix
@@ -88,7 +88,26 @@ let
     in
     result.success && result.value;
 
-  names = builtins.attrNames pkgs;
+  # texlive scheme environments (texliveBasic … texliveFull …) are buildEnv
+  # wrappers that pull in thousands of TeX packages.  Forcing drvPath on
+  # them re-evaluates every inner derivation (check-meta, dependency
+  # validation, etc.) even though those packages are already covered
+  # individually through `texlivePackages`.  texliveFull alone accounts for
+  # ~50 % of total eval time, so skip all scheme envs here.
+  texliveSchemes = [
+    "texliveBasic"
+    "texliveBookPub"
+    "texliveConTeXt"
+    "texliveFull"
+    "texliveGUST"
+    "texliveInfraOnly"
+    "texliveMedium"
+    "texliveMinimal"
+    "texliveSmall"
+    "texliveTeTeX"
+  ];
+
+  names = builtins.filter (n: !builtins.elem n texliveSchemes) (builtins.attrNames pkgs);
   manyVariantNames = builtins.attrNames (builtins.readDir ../pkgs-many);
 
   # Build named pairs { name; value; } for top-level attrs and variants.

--- a/pkgs-many/cmake/setup-hook.sh
+++ b/pkgs-many/cmake/setup-hook.sh
@@ -140,6 +140,26 @@ cmakeConfigurePhase() {
     runHook postConfigure
 }
 
+_fixCmakeIncludeDir() {
+    # When the include output is different from the main output, CMake-generated
+    # target files may contain INTERFACE_INCLUDE_DIRECTORIES entries relative to
+    # _IMPORT_PREFIX (e.g. "${_IMPORT_PREFIX}/include") that point into the main
+    # output where headers no longer exist.  Rewrite these to the absolute
+    # include output path so downstream find_package() calls work.
+    if [ "${!outputInclude}" = "${!outputDev}" ] && [ "${!outputInclude}" = "$out" ]; then
+        return
+    fi
+    local f
+    for f in $(find "${!outputLib}" "$out" -name '*.cmake' 2>/dev/null); do
+        if grep -q '${_IMPORT_PREFIX}/include' "$f" 2>/dev/null; then
+            echo "Patching CMake include path in $f to ${!outputInclude}/include"
+            sed -i "s|\\\${_IMPORT_PREFIX}/include|${!outputInclude}/include|g" "$f"
+        fi
+    done
+}
+
+postFixupHooks+=(_fixCmakeIncludeDir)
+
 addEnvHooks "$targetOffset" addCMakeParams
 
 makeCmakeFindLibs(){

--- a/pkgs/argp-standalone/default.nix
+++ b/pkgs/argp-standalone/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "argp-standalone";
   version = "1.5.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   src = fetchFromGitHub {
     owner = "argp-standalone";
     repo = "argp-standalone";

--- a/pkgs/aws-c-auth/default.nix
+++ b/pkgs/aws-c-auth/default.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation rec {
   pname = "aws-c-auth";
   version = "0.10.4";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-auth";

--- a/pkgs/aws-c-cal/default.nix
+++ b/pkgs/aws-c-cal/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation (finalAttrs: {
   # nixpkgs-update: no auto update
   version = "0.9.15";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-cal";

--- a/pkgs/aws-c-common/default.nix
+++ b/pkgs/aws-c-common/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
   # nixpkgs-update: no auto update
   version = "0.14.4";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-common";

--- a/pkgs/aws-c-compression/default.nix
+++ b/pkgs/aws-c-compression/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
   pname = "aws-c-compression";
   version = "0.3.2";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-compression";

--- a/pkgs/aws-c-event-stream/default.nix
+++ b/pkgs/aws-c-event-stream/default.nix
@@ -16,6 +16,12 @@ stdenv.mkDerivation rec {
   pname = "aws-c-event-stream";
   version = "0.7.1";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-event-stream";

--- a/pkgs/aws-c-http/default.nix
+++ b/pkgs/aws-c-http/default.nix
@@ -16,6 +16,12 @@ stdenv.mkDerivation rec {
   # nixpkgs-update: no auto update
   version = "0.11.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-http";

--- a/pkgs/aws-c-io/default.nix
+++ b/pkgs/aws-c-io/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
   # nixpkgs-update: no auto update
   version = "0.27.5";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-io";

--- a/pkgs/aws-c-mqtt/default.nix
+++ b/pkgs/aws-c-mqtt/default.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation rec {
   # nixpkgs-update: no auto update
   version = "0.16.1";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-mqtt";

--- a/pkgs/aws-c-s3/default.nix
+++ b/pkgs/aws-c-s3/default.nix
@@ -19,6 +19,12 @@ stdenv.mkDerivation rec {
   # nixpkgs-update: no auto update
   version = "0.13.5";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-s3";

--- a/pkgs/aws-c-sdkutils/default.nix
+++ b/pkgs/aws-c-sdkutils/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
   pname = "aws-c-sdkutils";
   version = "0.2.9";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-sdkutils";

--- a/pkgs/aws-checksums/default.nix
+++ b/pkgs/aws-checksums/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
   pname = "aws-checksums";
   version = "0.2.10";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-checksums";

--- a/pkgs/capstone/default.nix
+++ b/pkgs/capstone/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "capstone";
   version = "6.0.0-Alpha9";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "capstone-engine";
     repo = "capstone";

--- a/pkgs/catch2/default.nix
+++ b/pkgs/catch2/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
   pname = "catch2";
   version = "3.15.3";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "catchorg";
     repo = "Catch2";

--- a/pkgs/catch2_3/default.nix
+++ b/pkgs/catch2_3/default.nix
@@ -12,6 +12,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "catch2";
   version = "3.15.3";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "catchorg";
     repo = "Catch2";

--- a/pkgs/cereal/default.nix
+++ b/pkgs/cereal/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "cereal";
   version = "1.3.2";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "USCiLab";
     repo = "cereal";

--- a/pkgs/cmocka/default.nix
+++ b/pkgs/cmocka/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "cmocka";
   version = "1.1.8";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchurl {
     url = "https://cmocka.org/files/${lib.versions.majorMinor finalAttrs.version}/cmocka-${finalAttrs.version}.tar.xz";
     hash = "sha256-WENbVYdm1/THKboWO9867Di+07x2batoTjUm7Qqnx4A=";

--- a/pkgs/dconf/default.nix
+++ b/pkgs/dconf/default.nix
@@ -32,8 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "lib"
     "dev"
-  ]
-  ++ lib.optional withDocs "devdoc";
+  ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/dconf/${lib.versions.majorMinor finalAttrs.version}/dconf-${finalAttrs.version}.tar.xz";

--- a/pkgs/directx-headers/default.nix
+++ b/pkgs/directx-headers/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "directx-headers";
   version = "1.619.5";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "DirectX-Headers";

--- a/pkgs/doctest/default.nix
+++ b/pkgs/doctest/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "doctest";
   version = "2.5.3";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "doctest";
     repo = "doctest";

--- a/pkgs/eigen/default.nix
+++ b/pkgs/eigen/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "eigen";
   version = "3.4.1";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitLab {
     owner = "libeigen";
     repo = "eigen";

--- a/pkgs/gbenchmark/default.nix
+++ b/pkgs/gbenchmark/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
   pname = "gbenchmark";
   version = "1.9.5";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "google";
     repo = "benchmark";

--- a/pkgs/gflags/default.nix
+++ b/pkgs/gflags/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gflags";
   version = "2.3.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "gflags";
     repo = "gflags";

--- a/pkgs/grpc/default.nix
+++ b/pkgs/grpc/default.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "grpc";
   version = "1.83.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "grpc";
     repo = "grpc";

--- a/pkgs/hidapi/default.nix
+++ b/pkgs/hidapi/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "hidapi";
   version = "0.15.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "libusb";
     repo = "hidapi";

--- a/pkgs/libde265/default.nix
+++ b/pkgs/libde265/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1.1";
   pname = "libde265";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "strukturag";
     repo = "libde265";

--- a/pkgs/libdeflate/default.nix
+++ b/pkgs/libdeflate/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libdeflate";
   version = "1.25";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "ebiggers";
     repo = "libdeflate";

--- a/pkgs/libdisplay-info/default.nix
+++ b/pkgs/libdisplay-info/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libdisplay-info";
   version = "0.3.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "emersion";

--- a/pkgs/libharu/default.nix
+++ b/pkgs/libharu/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libharu";
   version = "2.4.6";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "libharu";
     repo = "libharu";

--- a/pkgs/libipt/default.nix
+++ b/pkgs/libipt/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
   pname = "libipt";
   version = "2.2";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "intel";
     repo = "libipt";

--- a/pkgs/libliftoff/default.nix
+++ b/pkgs/libliftoff/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libliftoff";
   version = "0.5.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "emersion";

--- a/pkgs/libpciaccess/default.nix
+++ b/pkgs/libpciaccess/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libpciaccess";
   version = "0.18.1";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     group = "xorg";

--- a/pkgs/libslirp/default.nix
+++ b/pkgs/libslirp/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libslirp";
   version = "4.9.1";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "slirp";

--- a/pkgs/libwebp/default.nix
+++ b/pkgs/libwebp/default.nix
@@ -38,6 +38,12 @@ stdenv.mkDerivation rec {
   pname = "libwebp";
   version = "1.6.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "webmproject";
     repo = "libwebp";

--- a/pkgs/libxcvt/default.nix
+++ b/pkgs/libxcvt/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libxcvt";
   version = "0.1.3";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     group = "xorg";

--- a/pkgs/libxi/default.nix
+++ b/pkgs/libxi/default.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
-    "man"
     "doc"
   ];
 

--- a/pkgs/libyuv/default.nix
+++ b/pkgs/libyuv/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation {
   pname = "libyuv";
   version = "1908"; # Defined in: include/libyuv/version.h
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchgit {
     url = "https://chromium.googlesource.com/libyuv/libyuv.git";
     rev = "b7a857659f8485ee3c6769c27a3e74b0af910746"; # upstream does not do tagged releases

--- a/pkgs/mesa/gbm.nix
+++ b/pkgs/mesa/gbm.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
   # so the updates need to happen separately on staging.
   version = "25.1.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "mesa";

--- a/pkgs/meson/setup-hook.sh
+++ b/pkgs/meson/setup-hook.sh
@@ -11,6 +11,12 @@ mesonConfigurePhase() {
         flagsArray+=("--prefix=$prefix")
     fi
 
+    # If the package declares an "include" output, route headers there
+    # automatically without requiring an explicit outputInclude attribute.
+    if [ -n "${include-}" ] && [ "$outputInclude" = "$outputDev" ]; then
+        outputInclude=include
+    fi
+
     # See multiple-outputs.sh and meson’s coredata.py
     flagsArray+=(
         "--libdir=${!outputLib}/lib"

--- a/pkgs/nlohmann_json/default.nix
+++ b/pkgs/nlohmann_json/default.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "nlohmann_json";
   version = "3.12.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "nlohmann";
     repo = "json";

--- a/pkgs/pixman/default.nix
+++ b/pkgs/pixman/default.nix
@@ -16,6 +16,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "pixman";
   version = "0.46.4";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "pixman";

--- a/pkgs/rapidfuzz-cpp/default.nix
+++ b/pkgs/rapidfuzz-cpp/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "rapidfuzz-cpp";
   version = "3.3.3";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "rapidfuzz";
     repo = "rapidfuzz-cpp";

--- a/pkgs/spice-protocol/default.nix
+++ b/pkgs/spice-protocol/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
   pname = "spice-protocol";
   version = "0.14.5";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   src = fetchurl {
     url = "https://www.spice-space.org/download/releases/${pname}-${version}.tar.xz";
     sha256 = "sha256-uvWESfbonRn0dYma1fuRlv3EbAPMUyM/TjnPKXj5z/c=";

--- a/pkgs/srt/default.nix
+++ b/pkgs/srt/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "srt";
   version = "1.5.5";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "Haivision";
     repo = "srt";

--- a/pkgs/svt-av1/default.nix
+++ b/pkgs/svt-av1/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "svt-av1";
   version = "2.3.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitLab {
     owner = "AOMediaCodec";
     repo = "SVT-AV1";

--- a/pkgs/taskflow/default.nix
+++ b/pkgs/taskflow/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "taskflow";
   version = "4.1.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "taskflow";
     repo = "taskflow";

--- a/pkgs/toml11/default.nix
+++ b/pkgs/toml11/default.nix
@@ -12,6 +12,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "toml11";
   version = "4.4.0";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "ToruNiina";
     repo = "toml11";

--- a/pkgs/utf8proc/default.nix
+++ b/pkgs/utf8proc/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "utf8proc";
   version = "2.11.3";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "JuliaStrings";
     repo = "utf8proc";

--- a/pkgs/wayland-protocols/default.nix
+++ b/pkgs/wayland-protocols/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "wayland-protocols";
   version = "1.45";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+
   doCheck =
     stdenv.hostPlatform == stdenv.buildPlatform
     &&

--- a/pkgs/xorgproto/default.nix
+++ b/pkgs/xorgproto/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "xorgproto";
   version = "2024.1";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     group = "xorg";
@@ -43,6 +49,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   # adds support for printproto needed for libXp
   mesonFlags = [ "-Dlegacy=true" ];
+
+  # xorgproto's meson.build generates .pc files with
+  # includedir=${prefix}/<absolute-includedir>. Fix the doubled prefix
+  # before _multioutDevs patches them further.
+  postInstall = ''
+    for f in "$out"/share/pkgconfig/*.pc; do
+      sed -i \
+        -e "s|^\(includedir=\).*|\1$include/include|" \
+        -e "s|\''${prefix}/\($include\)|\1|g" \
+        "$f"
+    done
+  '';
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/xxhash/default.nix
+++ b/pkgs/xxhash/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
   strictDeps = true;
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "Cyan4973";
     repo = "xxHash";

--- a/pkgs/zeromq/default.nix
+++ b/pkgs/zeromq/default.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "zeromq";
   version = "4.3.5";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "zeromq";
     repo = "libzmq";

--- a/pkgs/zziplib/default.nix
+++ b/pkgs/zziplib/default.nix
@@ -15,6 +15,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "zziplib";
   version = "0.13.80";
 
+  outputs = [
+    "out"
+    "include"
+  ];
+  outputInclude = "include";
+
   src = fetchFromGitHub {
     owner = "gdraheim";
     repo = "zziplib";


### PR DESCRIPTION
although usually fine to have headers in `dev`. it sometimes gets lumped in with propagated build inputs and other unrelated files. Since things like `__FILE__` can retain a reference to that out path, it's sometimes good to be able to have it exist independent from a potentially bloated `dev` output.