### PR TITLE
stdenv/linux: minimize xgcc build for faster bootstrap

### DIFF
--- a/stdenv/linux/default.nix
+++ b/stdenv/linux/default.nix
@@ -273,11 +273,7 @@ in
     stageFun prevStage {
       name = "bootstrap-stage1";
 
-      # Rebuild binutils to use from stage2 onwards.
       overrides = self: super: {
-        binutils-unwrapped = super.binutils-unwrapped.override {
-          enableGold = false;
-        };
         inherit (prevStage)
           ccWrapperStdenv
           gcc-unwrapped
@@ -340,6 +336,8 @@ in
           m4
           perl
           patchelf
+          nukeReferences
+          libxcrypt
           ;
         ${localSystem.libc} = prevStage.${localSystem.libc};
         # This stage also rebuilds binutils which will of course be used only in the next stage.
@@ -471,11 +469,9 @@ in
           bison
           texinfo
           which
+          nukeReferences
+          libxcrypt
           ;
-        dejagnu = super.dejagnu.overrideAttrs (a: {
-          doCheck = false;
-        });
-
         # Avoids infinite recursion, as this is in the build-time dependencies of libc.
         libiconv = self.libcIconv prevStage.libc;
 
@@ -586,6 +582,7 @@ in
             libidn2
             libunistring
             libxcrypt
+            nukeReferences
             ;
           # We build a special copy of libgmp which doesn't use libstdc++, because
           # xgcc++'s libstdc++ references the bootstrap-files (which is what

--- a/stdenv/linux/default.nix
+++ b/stdenv/linux/default.nix
@@ -376,6 +376,15 @@ in
               # which will cause compilation to fail with
               # configure: error: C compiler cannot create executables
               enableDefaultPie = false;
+
+              # xgcc is a throwaway compiler — disable Graphite loop optimizations
+              # (ISL) and unnecessary runtime libraries to speed up the build.
+              isl = null;
+              langFortran = false;
+              langGo = false;
+              langJit = false;
+              langObjC = false;
+              langObjCpp = false;
             }
           )).overrideAttrs
             (a: {
@@ -409,6 +418,12 @@ in
                 # Don't assume that `gettext` was built with iconv support, since we don't have
                 # our own `glibc` yet.
                 "--disable-nls"
+                # xgcc is only used to compile glibc and a handful of C/C++
+                # packages in the next stage — skip runtime libs that are
+                # unnecessary and expensive to build.
+                "--disable-libgomp"
+                "--disable-libquadmath"
+                "--disable-libsanitizer"
               ];
 
               # This is a separate phase because gcc assembles its phase scripts


### PR DESCRIPTION
Remove some features for the intermediate xgcc build which aren't used. Intermediate `isl` is no longer built, and 3 runtime libs.

Disable ISL (Graphite), unused language frontends, and unnecessary runtime libraries (libgomp, libquadmath, libsanitizer) for the throwaway xgcc compiler. This reduces xgcc build time by ~18% and output size by ~26 MiB without affecting the final stdenv.