### PR TITLE
Go, Rust, node, ruby ecosystems

### DIFF
--- a/pkgs-many/nodejs/default.nix
+++ b/pkgs-many/nodejs/default.nix
@@ -3,14 +3,22 @@
 mkManyVariants {
   variants = ./variants.nix;
   aliases = {
-    # Common aliases for Node.js versions
-    nodejs = "v22"; # Current LTS
-    nodejs_latest = "v23";
-    nodejs_22 = "v22";
-    nodejs_20 = "v20";
-    nodejs_18 = "v18";
+    # major version aliases pointing to the latest minor release
+    v18 = "v18_20";
+    v20 = "v20_20";
+    v22 = "v22_23";
+    v24 = "v24_20";
+    v26 = "v26_8";
+    # convenience aliases (must point to real variants, not other aliases)
+    nodejs = "v24_20";
+    nodejs_latest = "v26_8";
+    nodejs_18 = "v18_20";
+    nodejs_20 = "v20_20";
+    nodejs_22 = "v22_23";
+    nodejs_24 = "v24_20";
+    nodejs_26 = "v26_8";
   };
-  defaultSelector = (p: p.v22); # Default to Node.js 22 LTS
+  defaultSelector = (p: p.v24); # Default to Node.js 24 LTS
   genericBuilder = ./generic.nix;
   inherit callPackage;
 }

--- a/pkgs-many/nodejs/variants.nix
+++ b/pkgs-many/nodejs/variants.nix
@@ -1,25 +1,487 @@
 {
-  v18 = {
-    version = "18.20.5";
-    # Node.js 18 LTS (Maintenance)
-    src-hash = "sha256-dgN7m60KuTljSSgtv87BuHL/e9jI1piFO+vZgpQIWL8=";
+  # Node.js 18 (EOL)
+  v18_0 = {
+    version = "18.0.0";
+    src-hash = "sha256-NE0OZUC1JMaal5/1w+eM2nJU/XLANpmSa+sLhVi4znU=";
   };
 
-  v20 = {
-    version = "20.18.1";
-    # Node.js 20 LTS (Active)
-    src-hash = "sha256-kd9D+KtsP3voFSLXMxPb3VY0u8oijvDm2Taf4KuMzNA=";
+  v18_1 = {
+    version = "18.1.0";
+    src-hash = "sha256-6LDMIAieDXcmvA6SHSR/iDEmO9umtfECvZXqD2MwC34=";
   };
 
-  v22 = {
+  v18_2 = {
+    version = "18.2.0";
+    src-hash = "sha256-IwWxXr9VR0dOkFtQAvm6mcfu7wHXOU3+bzhGzGvK1m0=";
+  };
+
+  v18_3 = {
+    version = "18.3.0";
+    src-hash = "sha256-P2lKgWJuUFfNpXiY53HSE8/FpkmFX0zxxvbNFQxTBiU=";
+  };
+
+  v18_4 = {
+    version = "18.4.0";
+    src-hash = "sha256-lNbxmpcDYfjIrRdFBgQJU4n1HKagDc3lnCHzc+lau7U=";
+  };
+
+  v18_5 = {
+    version = "18.5.0";
+    src-hash = "sha256-NotWlOOAsF1DY2lIR1Rlmy8EDP4T/tAR66teUZjxoDA=";
+  };
+
+  v18_6 = {
+    version = "18.6.0";
+    src-hash = "sha256-X4sMM6EvyuyWQ7Q2el2qlDFL8m+bdbX0McTxSze8BUw=";
+  };
+
+  v18_7 = {
+    version = "18.7.0";
+    src-hash = "sha256-iDSjPJLf5rqJA+ZxXK6qJd/0ZX5wPFTNBuwRNJPiw8I=";
+  };
+
+  v18_8 = {
+    version = "18.8.0";
+    src-hash = "sha256-K12YJdBe3mYU8WaKjZfXdP6S68gQiOxf31gYTc48hrk=";
+  };
+
+  v18_9 = {
+    version = "18.9.1";
+    src-hash = "sha256-84GWPUNWi6aZkVyIYp3G2koZY4BNzTey5uHRDZI91dk=";
+  };
+
+  v18_10 = {
+    version = "18.10.0";
+    src-hash = "sha256-rXEbVOK+Sn0k83xz+ygBrer20m0pjUMb6Y1qvAIC6J8=";
+  };
+
+  v18_11 = {
+    version = "18.11.0";
+    src-hash = "sha256-i5ZD3G/OecHpk3nbDOZOQ2AeLi1ziQFf6JhcxMzQzhc=";
+  };
+
+  v18_12 = {
+    version = "18.12.1";
+    src-hash = "sha256-T6QGRRvFJlmikOUs/bIWKnYL1UnaS4u+vmop8pbZON8=";
+  };
+
+  v18_13 = {
+    version = "18.13.0";
+    src-hash = "sha256-/UrFYuAdFyiW46lZvVlVLb9kczHJDXJvjTRxaD3T2mg=";
+  };
+
+  v18_14 = {
+    version = "18.14.2";
+    src-hash = "sha256-+8Nk3SX+4srMDyAz2y2GEV/AdXUxDqDmRAi4Fw0JxoU=";
+  };
+
+  v18_15 = {
+    version = "18.15.0";
+    src-hash = "sha256-jkTWUBj/lzKEGVwjGGRpoOpAgul+xCAOX1cG1VhNqjc=";
+  };
+
+  v18_16 = {
+    version = "18.16.1";
+    src-hash = "sha256-6EBPjI2J/f336Vu7xgZr0OVxrLpY9USSWZthX77v4nI=";
+  };
+
+  v18_17 = {
+    version = "18.17.1";
+    src-hash = "sha256-8hXPA9DwDwesC2dMaBn4BMFULhbxUtoEmAAirsz15lo=";
+  };
+
+  v18_18 = {
+    version = "18.18.2";
+    src-hash = "sha256-ckni8K+UPsOFmVBPSyor0x+5OHhykbbMymyLrfAeO1Y=";
+  };
+
+  v18_19 = {
+    version = "18.19.1";
+    src-hash = "sha256-CQ+WouzeCAtrOCxtZCvKXQvkcCp4y1Vb578CsgvRbe0=";
+  };
+
+  v18_20 = {
+    version = "18.20.8";
+    src-hash = "sha256-Nqe/GnbWLOS63Yge5ZdKMjxw4djRkWVzJoThRWMkYNk=";
+  };
+
+  # Node.js 20 (EOL)
+  v20_0 = {
+    version = "20.0.0";
+    src-hash = "sha256-dFDnV5Vo99HLOYGFz85HLaKDeyqjbFliCyLOS5d7XLU=";
+  };
+
+  v20_1 = {
+    version = "20.1.0";
+    src-hash = "sha256-YA+eEYYJlYFLkSKxrFMY9q1WQnR4Te7ZjYqSBmSUNrU=";
+  };
+
+  v20_2 = {
+    version = "20.2.0";
+    src-hash = "sha256-IlI98jFsNVaXFP8fabBTwuKGztRgiYQX3uRpRe/N+Yk=";
+  };
+
+  v20_3 = {
+    version = "20.3.1";
+    src-hash = "sha256-EqgtswZpeVm0OJs1Gl+XhImGsTE/mQGw4LPYz08/mZE=";
+  };
+
+  v20_4 = {
+    version = "20.4.0";
+    src-hash = "sha256-Cb0Lc8UmtjwCnV3f2IXRCWLnrYfJdblFg8H4zpDuU0g=";
+  };
+
+  v20_5 = {
+    version = "20.5.1";
+    src-hash = "sha256-Q5xxqi84woYWV7+lOOmRkaVxJYBmy/1FSFhgScgTQZA=";
+  };
+
+  v20_6 = {
+    version = "20.6.1";
+    src-hash = "sha256-Ouxeco2qOIAMNDsSkiHTSIBkolKaObtUZ7xVviJsais=";
+  };
+
+  v20_7 = {
+    version = "20.7.0";
+    src-hash = "sha256-P8/c0FxGFRdIBZZZZnTfhbNc/OWX3QrjP1QW/E3xK+o=";
+  };
+
+  v20_8 = {
+    version = "20.8.1";
+    src-hash = "sha256-95nGb2pjhruKwsdaN490DEVel/H+lkOT3TnJ+fbvvHA=";
+  };
+
+  v20_9 = {
+    version = "20.9.0";
+    src-hash = "sha256-oj2WgQq/BFVCazSdR85TEPMwlbe8BXG5zFEPSBw6RRk=";
+  };
+
+  v20_10 = {
+    version = "20.10.0";
+    src-hash = "sha256-MuslbuvYys1VdOZjHlS0K+fsjr4lrUeoymhUA7rRVTU=";
+  };
+
+  v20_11 = {
+    version = "20.11.1";
+    src-hash = "sha256-d4E+2/P38W0tNdM1NEPe5OYdXuhNnjE4x1OKPAylIJ4=";
+  };
+
+  v20_12 = {
+    version = "20.12.2";
+    src-hash = "sha256-18vMX7+zHpAB8/AVC77aWavl3XE3qqYnOVjNWc41ztc=";
+  };
+
+  v20_13 = {
+    version = "20.13.1";
+    src-hash = "sha256-eReGoJAjJBy35PfWXskKqSS7ORQf97ttWh3t9970tOc=";
+  };
+
+  v20_14 = {
+    version = "20.14.0";
+    src-hash = "sha256-CGVQKPDYQ26IFj+RhgRNY10/Nqhe5Sjza9BbbF5Gwbs=";
+  };
+
+  v20_15 = {
+    version = "20.15.1";
+    src-hash = "sha256-/dU6VynZNmkaKhFRBG+0iXchy4sPyir5V4I6m0D+DDQ=";
+  };
+
+  v20_16 = {
+    version = "20.16.0";
+    src-hash = "sha256-zWyPw/8mBqrbxxVdtvfnckfS0AZawY4vfwSQlVhLi0Y=";
+  };
+
+  v20_17 = {
+    version = "20.17.0";
+    src-hash = "sha256-mr8DrCM2LGA4frtjOlFjA2NxRcs8F3vjNIsWiA/Ysow=";
+  };
+
+  v20_18 = {
+    version = "20.18.3";
+    src-hash = "sha256-BnTxbzvChMEXJM0/fCpD98LBPS63qHLdDbGY89WIxfI=";
+  };
+
+  v20_19 = {
+    version = "20.19.6";
+    src-hash = "sha256-ICb5/1LChtfH2ZkyshvjE9FzaupSTFr/F0jUGrC9miA=";
+  };
+
+  v20_20 = {
+    version = "20.20.2";
+    src-hash = "sha256-eu6s24WCmeCaPgUQ1LuLJmkjiUqeOsAFi6idTs9KTMo=";
+  };
+
+  # Node.js 22 LTS
+  v22_0 = {
+    version = "22.0.0";
+    src-hash = "sha256-IuKPv/MfaQc7gCTLQnReUQX4QEHzR1smC5fVoUEDnRo=";
+  };
+
+  v22_1 = {
+    version = "22.1.0";
+    src-hash = "sha256-nX1fQNnb1iYMmbXklLX5vHVejw/6xw4SGtzl+0QvI8s=";
+  };
+
+  v22_2 = {
+    version = "22.2.0";
+    src-hash = "sha256-iJkIqIKNFISRDX5lm2qlet6NUo/w45Dpp372WadihHQ=";
+  };
+
+  v22_3 = {
+    version = "22.3.0";
+    src-hash = "sha256-v7hb0dylF3YfkEbWFgD4MNGZNdbWw27e0BV4oZMmEEw=";
+  };
+
+  v22_4 = {
+    version = "22.4.1";
+    src-hash = "sha256-ZfyFf1qoJWqvyQCzRMARXJrq4loCVB/Vzg29Tf0cX7k=";
+  };
+
+  v22_5 = {
+    version = "22.5.1";
+    src-hash = "sha256-kk84GjLPJra+2+lf7t3jSEUPT9MhKD078/eWWqRc6DE=";
+  };
+
+  v22_6 = {
+    version = "22.6.0";
+    src-hash = "sha256-NyWdYY1VZcpVrMJYUEXH4cW5llo9TrRMCiN/2uhLnUQ=";
+  };
+
+  v22_7 = {
+    version = "22.7.0";
+    src-hash = "sha256-HgtvLyyk+wtGRKETYxadr0t8QvAOWlPSxlqf3EY+fYg=";
+  };
+
+  v22_8 = {
+    version = "22.8.0";
+    src-hash = "sha256-8TDoIXbR7gcC2Zr8GZXQBhv47TV8OINKMqCMnvdPGsc=";
+  };
+
+  v22_9 = {
+    version = "22.9.0";
+    src-hash = "sha256-pVrrNo3uk0MvYQEnz5TOaCqsB7k9y7qt2FbfEiySOd8=";
+  };
+
+  v22_10 = {
+    version = "22.10.0";
+    src-hash = "sha256-MYBxDTEwrZ3wFGar8BDkCNQbN0vlQwHRSA0Q7Kc1WOA=";
+  };
+
+  v22_11 = {
+    version = "22.11.0";
+    src-hash = "sha256-u/Apd2HVOu/anXhVxXx9LCcrg6e1utT+qcspAG2OHTU=";
+  };
+
+  v22_12 = {
     version = "22.12.0";
-    # Node.js 22 LTS (Current LTS)
     src-hash = "sha256-/hvEvgBNwSch6iy2cbCKId4BxpdpYO+KEkh5hYlnnhY=";
   };
 
-  v23 = {
-    version = "23.5.0";
-    # Node.js 23 (Latest)
-    src-hash = "sha256-Mud7NsB3TGi6q0G8fCrMWGY8oKK3xNPpvsb3YcFf2sA=";
+  v22_13 = {
+    version = "22.13.1";
+    src-hash = "sha256-z84oIRk5D34MIiBBCSRCjpDa3LLfF0TAxKDnuq44fMI=";
   };
+
+  v22_14 = {
+    version = "22.14.0";
+    src-hash = "sha256-xgmUa/eTtVx5VMJlgnYICNVMFhhdecsvuIBl5S3iGRQ=";
+  };
+
+  v22_15 = {
+    version = "22.15.1";
+    src-hash = "sha256-wZ8Bd9IcYhdGYl5fN1kL0NeacgQ7d7U3hMul8UXnJj4=";
+  };
+
+  v22_16 = {
+    version = "22.16.0";
+    src-hash = "sha256-cgiU8yPlwawklo6yZ2ZgyQcw1xXLfwkL5xpmhmKhfDc=";
+  };
+
+  v22_17 = {
+    version = "22.17.1";
+    src-hash = "sha256-MnQV/Xb867mBM79W4tkOOsBIsDj6wmdvA7bbkQdFdbk=";
+  };
+
+  v22_18 = {
+    version = "22.18.0";
+    src-hash = "sha256-Eg4PdEGQl6n6+uH9gLned5Glh+bxxIwisZMjnM0PcIQ=";
+  };
+
+  v22_19 = {
+    version = "22.19.0";
+    src-hash = "sha256-AnKs/OUM6a0GAogyGxCScZp/GZZvgUGYNUEMWcCdqkY=";
+  };
+
+  v22_20 = {
+    version = "22.20.0";
+    src-hash = "sha256-/3pqbooTEq9YdeQAWDUcT4kNKKtkwy8SsswZmvoiAC0=";
+  };
+
+  v22_21 = {
+    version = "22.21.1";
+    src-hash = "sha256-SH1z/U2wDcJCDWWagiGxgaeTf7xbxz8xwwsWgK1t7Wo=";
+  };
+
+  v22_22 = {
+    version = "22.22.3";
+    src-hash = "sha256-8+aleNsaszWkpyeFweh60Yos9tL8JXR6HXQfs0rwvQ8=";
+  };
+
+  v22_23 = {
+    version = "22.23.2";
+    src-hash = "sha256-u+do341YFdf6dhJAUphTMkUuCkdC058yAnVQ0aq49vs=";
+  };
+
+  # Node.js 24 LTS
+  v24_0 = {
+    version = "24.0.2";
+    src-hash = "sha256-FZcHWvwG5cYUXQv7134gcsLsCrcaxJUM8AiyZBN0zXE=";
+  };
+
+  v24_1 = {
+    version = "24.1.0";
+    src-hash = "sha256-yBcbKuzLKMjFNH8nOiWtrhcvsqZbyMl1vCLsWJSdDq8=";
+  };
+
+  v24_2 = {
+    version = "24.2.0";
+    src-hash = "sha256-QBQ9Q++97rlTeZX1MhJsSU1jox2jMqy1Ai928Ar8Yqs=";
+  };
+
+  v24_3 = {
+    version = "24.3.0";
+    src-hash = "sha256-62iO+KY/2p68C1+QdgmkbibbbZrO78CDIAmpg3Hpku0=";
+  };
+
+  v24_4 = {
+    version = "24.4.1";
+    src-hash = "sha256-rbecoJh0hu1mE2IT2hn/F+9nJNyzQMMg4BDJRCEBZS8=";
+  };
+
+  v24_5 = {
+    version = "24.5.0";
+    src-hash = "sha256-8bqWIEckvRxt53WOCLNxi6C0XYf7O+vX4wCXh0zMgTA=";
+  };
+
+  v24_6 = {
+    version = "24.6.0";
+    src-hash = "sha256-itXDh7XVXY87eDsPGyG64Do7OxCsiaJdJmz/p7eV6EI=";
+  };
+
+  v24_7 = {
+    version = "24.7.0";
+    src-hash = "sha256-z3Snd1O2Kf/r0uOPsVOiEAGyt6PDZcDsczKxILmMclE=";
+  };
+
+  v24_8 = {
+    version = "24.8.0";
+    src-hash = "sha256-HAOzYuv0dA1HWLmj0wh+PemJ9UgjZQ7IC0cJDvQUsuA=";
+  };
+
+  v24_9 = {
+    version = "24.9.0";
+    src-hash = "sha256-8XvEywH1kJjDSiiMG7EJp3iGfBTusOu9YI0GF7EZO78=";
+  };
+
+  v24_10 = {
+    version = "24.10.0";
+    src-hash = "sha256-8X42yyzIw0qSFbpXtVznkbEC4pNDLtR61jy68V94Z48=";
+  };
+
+  v24_11 = {
+    version = "24.11.1";
+    src-hash = "sha256-6k2jXxyco3bsaDfh4wzuMNSRhH/hUqPwN43BFW2VS70=";
+  };
+
+  v24_12 = {
+    version = "24.12.0";
+    src-hash = "sha256-bT6JGgFrkPbGoZ6ly8nJDFfu+RmGcLqT8E+oKvAldK4=";
+  };
+
+  v24_13 = {
+    version = "24.13.1";
+    src-hash = "sha256-sie8ho+16eyGcGIOKyVTDrEsF9Q+bHvFG7OKZgaEGS0=";
+  };
+
+  v24_14 = {
+    version = "24.14.1";
+    src-hash = "sha256-eCJQdxPyAs8qVRiZ0lAllkP0d7ZxcG20Iab7VcSqCZE=";
+  };
+
+  v24_15 = {
+    version = "24.15.0";
+    src-hash = "sha256-pPZT157RQKqtkh6MIqO1hcqFz9q4DUAw9jCeRmOoocg=";
+  };
+
+  v24_16 = {
+    version = "24.16.0";
+    src-hash = "sha256-L/hKbecLYWUpARGw/GVt7RrSB6eZgW/nIMx8MSMt8w8=";
+  };
+
+  v24_17 = {
+    version = "24.17.0";
+    src-hash = "sha256-p6tWLtI2minGi3L6AOMQO83+NwY9/3mcasyOQE4nX80=";
+  };
+
+  v24_18 = {
+    version = "24.18.1";
+    src-hash = "sha256-htQNWUu9/PaQCaYv30PLGa5ytstYItK92DScWhsvpig=";
+  };
+
+  v24_19 = {
+    version = "24.19.0";
+    src-hash = "sha256-9tleEKBDHuEGf8aqvp92KQi0cW3TUyTh3bSxRmt2ZZ8=";
+  };
+
+  v24_20 = {
+    version = "24.20.0";
+    src-hash = "sha256-JzL8P1iN0zXNZ3nAaGT3zUJLsbX/mhdDBZpmxU+cpKE=";
+  };
+
+  # Node.js 26 (Current)
+  v26_0 = {
+    version = "26.0.0";
+    src-hash = "sha256-/LXlwGpcLsnmaYASSGV6r6oikfh2Dax7+2Ofh4MYxZI=";
+  };
+
+  v26_1 = {
+    version = "26.1.0";
+    src-hash = "sha256-d5oTZIiVddROAhWtw4GAa70NlDdVe1mJPhcvW501qZA=";
+  };
+
+  v26_2 = {
+    version = "26.2.0";
+    src-hash = "sha256-6oK+fbQY9Us+8VOgLUTU9nSEZvR2WugLxITzSvQN9hA=";
+  };
+
+  v26_3 = {
+    version = "26.3.1";
+    src-hash = "sha256-l5ubgwio0tSifGYu1QRIyF+XDA/U9c6LmOjaeMRB8rw=";
+  };
+
+  v26_4 = {
+    version = "26.4.0";
+    src-hash = "sha256-ns6zYhAkBp2RA1tUcdLr6GqgTSLb66cqeC6vNv+Rg6w=";
+  };
+
+  v26_5 = {
+    version = "26.5.1";
+    src-hash = "sha256-33dwqamTRvi3O6bTGtib1vhotRxzh8NifctEygZfSUg=";
+  };
+
+  v26_6 = {
+    version = "26.6.0";
+    src-hash = "sha256-7LbuyBJQXJKSUpCHokNuxsiR/+DjqJeDNBbl10NtZZ8=";
+  };
+
+  v26_7 = {
+    version = "26.7.0";
+    src-hash = "sha256-5rGCy+6rAy0QgspKxP4V46V95pHTveeOz4p2H9Vu41Y=";
+  };
+
+  v26_8 = {
+    version = "26.8.1";
+    src-hash = "sha256-0WmIMqGhDwUM3aBEo+PWp0gkaBHi57yJupqL1pPcRfI=";
+  };
+
 }

--- a/pkgs-many/pnpm/default.nix
+++ b/pkgs-many/pnpm/default.nix
@@ -3,13 +3,18 @@
 mkManyVariants {
   variants = ./variants.nix;
   aliases = {
-    # Common aliases for pnpm versions
-    pnpm = "v11"; # Latest stable
-    pnpm_11 = "v11";
-    pnpm_10 = "v10";
+    # major version aliases pointing to the latest minor release
+    v8 = "v8_15";
+    v9 = "v9_15";
+    v10 = "v10_34";
+    v11 = "v11_25";
+    # convenience aliases (must point to real variants, not other aliases)
+    pnpm = "v11_25";
+    pnpm_8 = "v8_15";
+    pnpm_9 = "v9_15";
+    pnpm_10 = "v10_34";
     pnpm_10_29_2 = "v10_29_2";
-    pnpm_9 = "v9";
-    pnpm_8 = "v8";
+    pnpm_11 = "v11_25";
   };
   defaultSelector = (p: p.v11); # Default to pnpm 11
   genericBuilder = ./generic.nix;

--- a/pkgs-many/pnpm/generic.nix
+++ b/pkgs-many/pnpm/generic.nix
@@ -34,18 +34,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     installShellFiles
-    nodejs.v23
+    nodejs
   ];
 
   buildInputs = [
     bashNonInteractive # needed for node-gyp wrapper script
   ]
-  ++ lib.optionals withNode [ nodejs.v23 ];
+  ++ lib.optionals withNode [ nodejs ];
 
   # Remove binary files from src, we don't need them, and this way we make sure
   # our distribution is free of binaryNativeCode
   postUnpack = ''
-    rm -r package/dist/reflink.*node package/dist/vendor
+    rm -rf package/dist/reflink.*node package/dist/vendor
   '';
 
   installPhase =

--- a/pkgs-many/pnpm/variants.nix
+++ b/pkgs-many/pnpm/variants.nix
@@ -1,29 +1,477 @@
 {
-  v8 = {
+  # pnpm 8.x
+  v8_0 = {
+    version = "8.0.0";
+    hash = "sha256-J3B9OROmDO++Y6HBoFexqYYY8z4/fjHNy9yBGmGhAa0=";
+  };
+
+  v8_1 = {
+    version = "8.1.1";
+    hash = "sha256-gfpC6uk1cPVpRg3vHMCti7dgGiUwS+b2F0KmmiLWZFw=";
+  };
+
+  v8_2 = {
+    version = "8.2.0";
+    hash = "sha256-FfVjlSk2PGfEegOCeADgzp3wcuWXZb07UzS7tQ786eY=";
+  };
+
+  v8_3 = {
+    version = "8.3.1";
+    hash = "sha256-zgOLomF/epPQsfJLczudZCWLFcl6FMbzdnPI1J4DPZo=";
+  };
+
+  v8_4 = {
+    version = "8.4.0";
+    hash = "sha256-0ajvHfWsCyiYwVf9sFauFv8WeruW2PFT6vX4uII6Kbw=";
+  };
+
+  v8_5 = {
+    version = "8.5.1";
+    hash = "sha256-Qi3LOvYe5EssVdhzciZZATT49QCeYX/nCHNNOmmlCBE=";
+  };
+
+  v8_6 = {
+    version = "8.6.12";
+    hash = "sha256-PtQP/Gy7AHkKsyXp0/9VF6PtW3Y+xTpBFwexcCpBEXQ=";
+  };
+
+  v8_7 = {
+    version = "8.7.6";
+    hash = "sha256-yVhp1EPtj9a3uxZLuOibVsq9wk88ebh+9o2K4cax0OI=";
+  };
+
+  v8_8 = {
+    version = "8.8.0";
+    hash = "sha256-1xOldQ5Bw2YNHgkGCMf2B60A0d1bqbZVK185C/N5JOk=";
+  };
+
+  v8_9 = {
+    version = "8.9.2";
+    hash = "sha256-jWJXPZMGHycit7SMlznpbNRgPDqxU7yBxhncuYYaIU4=";
+  };
+
+  v8_10 = {
+    version = "8.10.5";
+    hash = "sha256-pL2bt7SCFLv82V8mS9dbtw0QDl1LWICPXNarQMasIcU=";
+  };
+
+  v8_11 = {
+    version = "8.11.0";
+    hash = "sha256-WFiAbDspLL7Im1UzZiFoqVc1jiu9hkMVFtRB3Br6zok=";
+  };
+
+  v8_12 = {
+    version = "8.12.1";
+    hash = "sha256-KMph7OWklhSLc/q8mvuCD5w/7E9V8EzkWizqClIZ8uE=";
+  };
+
+  v8_13 = {
+    version = "8.13.1";
+    hash = "sha256-nl9izl8rfUzrPChI9BzwszAywk1oPHCItT9isYhfskY=";
+  };
+
+  v8_14 = {
+    version = "8.14.3";
+    hash = "sha256-LQNju2wxTapnCH7wd0PuobouLTYMg16P7GtVdeTtlIQ=";
+  };
+
+  v8_15 = {
     version = "8.15.9";
     hash = "sha256-2qJ6C1QbxjUyP/lsLe2ZVGf/n+bWn/ZwIVWKqa2dzDY=";
   };
 
-  v9 = {
+  # pnpm 9.x
+  v9_0 = {
+    version = "9.0.6";
+    hash = "sha256-BiTjDv+GbN6zY7FQYb23/ZQlsXvBu0LCL19O/eoh9rM=";
+  };
+
+  v9_1 = {
+    version = "9.1.4";
+    hash = "sha256-MKGAGsTnI3ee/tE6IfTDn562yfu0ztEBvOBrQiWT18k=";
+  };
+
+  v9_2 = {
+    version = "9.2.0";
+    hash = "sha256-lPqyE98iHFW2lWsUoiZMIcYgPMqfCzuV/y/puEsSA5A=";
+  };
+
+  v9_3 = {
+    version = "9.3.0";
+    hash = "sha256-4fno0aFmB6Rt08FYtfen3HlFUB0cYiLUVNY9Az0dkY8=";
+  };
+
+  v9_4 = {
+    version = "9.4.0";
+    hash = "sha256-tv0L/aVV5+WErX5WswxosB1aBPnuk5ifS5PKhHPEnHQ=";
+  };
+
+  v9_5 = {
+    version = "9.5.0";
+    hash = "sha256-299ZYcMpCfsDBZWp2qHa5yAWLmWGCaj5Ly+pmDVRDKU=";
+  };
+
+  v9_6 = {
+    version = "9.6.0";
+    hash = "sha256-2uD36CLFayCXm7WWXjtzuL2rtri47xIdpthXUIWZyjU=";
+  };
+
+  v9_7 = {
+    version = "9.7.1";
+    hash = "sha256-RvG7yPgCCqmGlWjDhxmPGoE/IftEyC9ADn0dvebHC0A=";
+  };
+
+  v9_8 = {
+    version = "9.8.0";
+    hash = "sha256-Vqnna1F5bKf3O4XkTPg3EoYgkfTUmMDOTVt+zca6GPc=";
+  };
+
+  v9_9 = {
+    version = "9.9.0";
+    hash = "sha256-ekJh5Q2aRNkkC69snW4QCJ3PCnnQAH8qJphaaScyQXc=";
+  };
+
+  v9_10 = {
+    version = "9.10.0";
+    hash = "sha256-NVqKuNu2rUG+++85vE/Wtd+F4Sdh0nJL0B8T6HjeSxM=";
+  };
+
+  v9_11 = {
+    version = "9.11.0";
+    hash = "sha256-HA4z9w5d+e7ehKNXvfoLH526blgZRijUihBVdW9VN1Q=";
+  };
+
+  v9_12 = {
+    version = "9.12.3";
+    hash = "sha256-JCNXcsxKyCpiYnzUf4NMcmZ6LOh3mahG7E6OVV4tS4s=";
+  };
+
+  v9_13 = {
+    version = "9.13.2";
+    hash = "sha256-zM6Bv3SYxfD4DjF0nB+PA7q6mdFo9kWQ/H4T+tPqGTg=";
+  };
+
+  v9_14 = {
+    version = "9.14.4";
+    hash = "sha256-JqcmtjO2KaP6vaAG9pauQmCVSjYyyAVBEteuiXeeX5o=";
+  };
+
+  v9_15 = {
     version = "9.15.9";
     hash = "sha256-z4anrXZEBjldQoam0J1zBxFyCsxtk+nc6ax6xNxKKKc=";
   };
 
-  # 10.29.3 made a breaking change: https://github.com/pnpm/pnpm/issues/10601.
-  # Pnpm packages that depend on electron builder must be upgraded to 26.8.2 or newer
-  # otherwise a runtime error will occur when launching the application.
-  v10_29_2 = {
-    version = "10.29.2";
-    hash = "sha256-hAL2daH0zJ1PJ7v6s1wtSi4dfrATHfA9rQlhnoZnTQw=";
+  # pnpm 10.x
+  v10_0 = {
+    version = "10.0.0";
+    hash = "sha256-Q6v25yD7e8U8WRsIYmBcfTI9Cp0t0zvKwHsGLhPPSUg=";
   };
 
-  v10 = {
+  v10_1 = {
+    version = "10.1.0";
+    hash = "sha256-PuU+kUAR7H8abjqwxYuaAkoFK/4YKVsjtoVn1qal680=";
+  };
+
+  v10_2 = {
+    version = "10.2.1";
+    hash = "sha256-+Yjw2TuH4dotjN9qx/RaAcb4Q642BrTKDy/9cTuF+XU=";
+  };
+
+  v10_3 = {
+    version = "10.3.0";
+    hash = "sha256-JN1cZdhsfQcQq6FmmfvEbXT8ms8rQZ9JRSB/LenlfiM=";
+  };
+
+  v10_4 = {
+    version = "10.4.1";
+    hash = "sha256-S3Aoh5hplZM9QwCDawTW0CpDvHK1Lk9+k6TKYIuVkZc=";
+  };
+
+  v10_5 = {
+    version = "10.5.2";
+    hash = "sha256-eamNqpAki1CBXjFGB5DxGMVv4JkRM3CCbKoBU75tq6U=";
+  };
+
+  v10_6 = {
+    version = "10.6.5";
+    hash = "sha256-R8i8pCtLSFNLWxso1XPFBnc5N7AvaOUpkvvYJpExxcg=";
+  };
+
+  v10_7 = {
+    version = "10.7.1";
+    hash = "sha256-3FFIkOpxkAPLelfWshryT9r63Z8XHnVn7KFmXXz873Y=";
+  };
+
+  v10_8 = {
+    version = "10.8.1";
+    hash = "sha256-2LLrvGXPAsNJ7Ka0XJZAuRDxa2revbe5JunbRA5Hysc=";
+  };
+
+  v10_9 = {
+    version = "10.9.0";
+    hash = "sha256-6lOrdHrIt5Id5jtC6rGt8CHh/m3tBfYvAIhcwzpGEY0=";
+  };
+
+  v10_10 = {
+    version = "10.10.0";
+    hash = "sha256-+g9ROqgZF2TStrQyQgeIwnDwe0+ZkJm2W7IBDuxwKjA=";
+  };
+
+  v10_11 = {
+    version = "10.11.1";
+    hash = "sha256-IR6ZkBSElcn8MLflg5b37tqD2SQ+t1QH6k+GUPsWH3w=";
+  };
+
+  v10_12 = {
+    version = "10.12.4";
+    hash = "sha256-yt/Z5sn8wst2/nwHeaUlC2MomK6l9T2DOnNpDHeneNk=";
+  };
+
+  v10_13 = {
+    version = "10.13.1";
+    hash = "sha256-D57UjYCJlq4AeDX7XEZBz5owDe8u3cnpV9m75HaMXyg=";
+  };
+
+  v10_14 = {
+    version = "10.14.0";
+    hash = "sha256-KXU05l1YQkUFOcHoAiyIMateH+LrdGZHh6gVUZVC1iA=";
+  };
+
+  v10_15 = {
+    version = "10.15.1";
+    hash = "sha256-jFOvAq4+wfsK51N3+NTWIXwtfL5vA8FjUMq/dJPebv8=";
+  };
+
+  v10_16 = {
+    version = "10.16.1";
+    hash = "sha256-t36Sug1ZpjcrbFBBu7P4ZvuF6SffMzgn8Mf1d8XhpxM=";
+  };
+
+  v10_17 = {
+    version = "10.17.1";
+    hash = "sha256-oeATP2gBwTA5rkEwnl5afRBYo6Hh7dAgpJRKg8U2jQQ=";
+  };
+
+  v10_18 = {
+    version = "10.18.3";
+    hash = "sha256-eX0AWbxfwzVtecaBYVoTfHs15O/AOkRJqKGr/LzEvcc=";
+  };
+
+  v10_19 = {
+    version = "10.19.0";
+    hash = "sha256-HF9e5ZJn5OLhv9M19DKhjcSPmplECU1dJkl1fnJa03Y=";
+  };
+
+  v10_20 = {
+    version = "10.20.0";
+    hash = "sha256-R6M1KAhQG40e8gESJztqXc+lPSilW8zjbSaOh4vWv+k=";
+  };
+
+  v10_21 = {
+    version = "10.21.0";
+    hash = "sha256-bz3yGXvQF6l/GvXrmrGajPGuQbzFkXzzbVBbyag7lXg=";
+  };
+
+  v10_22 = {
+    version = "10.22.0";
+    hash = "sha256-BTqEk+jjKKPG1/9csHm+8ocZFSzPgx5GZrXAMyt3u4g=";
+  };
+
+  v10_23 = {
+    version = "10.23.0";
+    hash = "sha256-oc3XtGg4ap14oIHaBdYEnX5ZjbYqKZ25LfIacGKksYM=";
+  };
+
+  v10_24 = {
+    version = "10.24.0";
+    hash = "sha256-GW9L0XTry9mXhrM0UvFEyy3DLvTnE47URJHp1D1wLXU=";
+  };
+
+  v10_25 = {
+    version = "10.25.0";
+    hash = "sha256-DzcmZUsLXlLlgAkE3haK/Dxmfiq/hL2wbZrBOGEEvZA=";
+  };
+
+  v10_26 = {
+    version = "10.26.2";
+    hash = "sha256-Y7UKS6Fc3iAAbdul2eIf1iPiPwlMn2O7FfaGsOSWrtY=";
+  };
+
+  v10_27 = {
+    version = "10.27.0";
+    hash = "sha256-08fD0S2H0XfjLwF0jVmU+yDNW+zxFnDuYFMMN0/+q7M=";
+  };
+
+  v10_28 = {
+    version = "10.28.2";
+    hash = "sha256-r6mbC0s9EcHa0rRy+TGK4seGc4KXSd7VJ/ifCQcUeac=";
+  };
+
+  v10_29 = {
+    version = "10.29.3";
+    hash = "sha256-p09NvT9afKh00AQTUnHwtpe2g78f0vwhM5YRYc0lspw=";
+  };
+
+  v10_30 = {
+    version = "10.30.3";
+    hash = "sha256-/wpyFA9qbWbAsoT2yVYK/2BVGOKMKa6sJfsmK3QzFYg=";
+  };
+
+  v10_31 = {
+    version = "10.31.0";
+    hash = "sha256-b2HO0aJ1WNE831IAjyuzAqA2OP8J3SNlYql/CsWdN8M=";
+  };
+
+  v10_32 = {
+    version = "10.32.1";
+    hash = "sha256-m5Q7lLyPVe+5k6rY5EtTjmsJHmCp5KlE3N6GmFXyM+M=";
+  };
+
+  v10_33 = {
+    version = "10.33.4";
+    hash = "sha256-jnDdxmSbGLw9iVzzqQjAKR6kw4A5rYcixH4Bja8enPw=";
+  };
+
+  v10_34 = {
     version = "10.34.5";
     hash = "sha256-zLXEecqxsAYhMlv+fUyaioAx56Ul1ySeJ17L7IGwjbI=";
   };
 
-  v11 = {
+  # pnpm 11.x
+  v11_0 = {
+    version = "11.0.9";
+    hash = "sha256-TYTXsOMckFT2Flh5VpgHAAfQO3I4SB4hYaViVXqpCDQ=";
+  };
+
+  v11_1 = {
+    version = "11.1.3";
+    hash = "sha256-dAMC/naKrxumgMUhO9CJg/IZ4LzwyWwMbXvjk7hiDJg=";
+  };
+
+  v11_2 = {
+    version = "11.2.2";
+    hash = "sha256-mcS+gx7SMYKYlRQtlnk9vnWvxTeVkzrtg2bmjczh4bg=";
+  };
+
+  v11_3 = {
+    version = "11.3.0";
+    hash = "sha256-Wt4e9RzzZEH0oAkx6vkANlRonro2hJOfcNdXay37hHQ=";
+  };
+
+  v11_4 = {
+    version = "11.4.0";
+    hash = "sha256-50EGpaDrJWn0WDUEQg6tX8HCY+QXoyFsqxy+DM3LTq4=";
+  };
+
+  v11_5 = {
+    version = "11.5.3";
+    hash = "sha256-I41jmkdxIni7cui22ywpesHM2A3XZC98kztzrr3ntR8=";
+  };
+
+  v11_6 = {
+    version = "11.6.0";
+    hash = "sha256-oBYpSdGrGeEuizzZ8PWe8C1750oouAbPf0n7f0wH5c4=";
+  };
+
+  v11_7 = {
+    version = "11.7.0";
+    hash = "sha256-3q+n7JihIYtqBHKJuS++I5XB4i00lbtxFlMBMhjuFe4=";
+  };
+
+  v11_8 = {
+    version = "11.8.0";
+    hash = "sha256-HpY6XEylFoVQugP8TujYc6dysHK3/OY7SP/yfXIOLpg=";
+  };
+
+  v11_9 = {
+    version = "11.9.0";
+    hash = "sha256-K1Z6pmAmI4B4rC4KM77D/r1g6WKYeqxpdFbzGAgZsoc=";
+  };
+
+  v11_10 = {
+    version = "11.10.0";
+    hash = "sha256-YgtmBepPYvxWptCphzP0eQcdAyHgPkhrUix+mnRhdDE=";
+  };
+
+  v11_11 = {
+    version = "11.11.0";
+    hash = "sha256-he8u/yFqGukIBMAMjfv6ZoU1NkRlDRCQaok8Ba7c2IQ=";
+  };
+
+  v11_12 = {
+    version = "11.12.0";
+    hash = "sha256-HCvxCNdnuXY1PCwemtFNJAzruZ1L702Tp/Gp0Q2luBc=";
+  };
+
+  v11_13 = {
+    version = "11.13.1";
+    hash = "sha256-EAErV9I7lnO8U0Fo/1axrGVbpKJzf/N/bZ0ZpVFEr6o=";
+  };
+
+  v11_14 = {
+    version = "11.14.0";
+    hash = "sha256-zGCsw/y0E9R0HNFoAOnZ2OaOaA5XHkm4SEijki6ZGD0=";
+  };
+
+  v11_15 = {
+    version = "11.15.1";
+    hash = "sha256-J0YGKbEBEWBOf5iIJ1O1M5iYaCDCDgoGXzpKXp59tx8=";
+  };
+
+  v11_16 = {
+    version = "11.16.0";
+    hash = "sha256-PyqEhUX4L85pZvPsqot9h7VWP5AaFw4r1XOwIpazgvo=";
+  };
+
+  v11_17 = {
+    version = "11.17.0";
+    hash = "sha256-ZE61B5ZU6H2uWaB+YtfwmBYrnOWPBgdzKLXd78ochUE=";
+  };
+
+  v11_18 = {
+    version = "11.18.0";
+    hash = "sha256-KcNcqNKih5iP3uPg824H2bk3g/VntXm3/Vt5ikVj3YE=";
+  };
+
+  v11_19 = {
+    version = "11.19.0";
+    hash = "sha256-ueSWA1QNBBB7mOk5F6MOYRSXDUA8I+QDCaROqcK8p/0=";
+  };
+
+  v11_20 = {
+    version = "11.20.0";
+    hash = "sha256-NOGYyx5DI3UX7O39MfmuJqbAo+U2bOWKLQX0sh+18Zo=";
+  };
+
+  v11_21 = {
+    version = "11.21.0";
+    hash = "sha256-hyN9N+rbedxiagV26zpS0j1wQiwyOuXgD8BckfQyN4A=";
+  };
+
+  v11_22 = {
     version = "11.22.0";
     hash = "sha256-V6l+byOj+v/AMVOk74x3CgVSYSuGQK6+Ob/dV1TQ69w=";
+  };
+
+  v11_23 = {
+    version = "11.23.0";
+    hash = "sha256-eNy/RPQM71DR9LU1yplhow7bSxPEIMNgv0Bo1CSkG8Q=";
+  };
+
+  v11_24 = {
+    version = "11.24.0";
+    hash = "sha256-0eqyQzFyZhzDahjshfzpP3cdsZYnFzKcwB7JwoJMok8=";
+  };
+
+  v11_25 = {
+    version = "11.25.0";
+    hash = "sha256-M90HSPJ+eRbE8ci2lDRhmD40U7BrvaYxKmKAEwtIgeU=";
+  };
+
+  # Pinned: 10.29.3 made a breaking change (pnpm/pnpm#10601)
+  # Packages depending on electron-builder must use 10.29.2 or upgrade electron-builder to 26.8.2+
+  v10_29_2 = {
+    version = "10.29.2";
+    hash = "sha256-hAL2daH0zJ1PJ7v6s1wtSi4dfrATHfA9rQlhnoZnTQw=";
   };
 }

--- a/pkgs-many/ruby/default.nix
+++ b/pkgs-many/ruby/default.nix
@@ -2,7 +2,13 @@
 
 mkManyVariants {
   variants = ./variants.nix;
-  defaultSelector = (p: p.v3_3);
+  aliases = {
+    # major.minor aliases pointing to the latest patch release
+    v3_3 = "v3_3_12";
+    v3_4 = "v3_4_10";
+    v4_0 = "v4_0_6";
+  };
+  defaultSelector = (p: p.v3_4);
   genericBuilder = ./generic.nix;
   inherit callPackage;
 }

--- a/pkgs-many/ruby/variants.nix
+++ b/pkgs-many/ruby/variants.nix
@@ -2,23 +2,198 @@
 
 let
   rubyVersion = import ./ruby-version.nix { inherit lib; };
+
+  cargoHash_3_3 = "sha256-xE7Cv+NVmOHOlXa/Mg72CTSaZRb72lOja98JBvxPvSs=";
+  cargoHash_3_4 = "sha256-5Tp8Kth0yO89/LIcU8K01z6DdZRr8MAA0DPKqDEjIt0=";
+  cargoHash_4_0 = "sha256-z7NwWc4TaR042hNx0xgRkh/BQEpEJtE53cfrN0qNiE0=";
 in
 {
-  v3_3 = {
+  # Ruby 3.3.x
+  v3_3_0 = {
+    version = rubyVersion "3" "3" "0" "";
+    hash = "sha256-llGIFNmDK+zpKoVBWoGdSJOzB9tZIa4fD3Uamomla30=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_1 = {
+    version = rubyVersion "3" "3" "1" "";
+    hash = "sha256-jcKvKALMcAzRgtVDByY4jM+IWz8KFPzWoPIf8knJqpk=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_2 = {
+    version = rubyVersion "3" "3" "2" "";
+    hash = "sha256-O+HRAOvyoM5gws2NIs2dtNZLPgShlDvixP97Ug8ry1s=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_3 = {
+    version = rubyVersion "3" "3" "3" "";
+    hash = "sha256-g8BbIXfunDNbYxspuMB3tHcBZtAvpSfzqfakDRPzzOI=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_4 = {
+    version = rubyVersion "3" "3" "4" "";
+    hash = "sha256-/mow+X1U4Cl2jy3fSSNpnEFs28Om6W2z4tVxbH25ajQ=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_5 = {
+    version = rubyVersion "3" "3" "5" "";
+    hash = "sha256-N4GjUEIiwvJstLnrnBoS2/SUTTZs4kqf+M+Z7LznUZY=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_6 = {
+    version = rubyVersion "3" "3" "6" "";
+    hash = "sha256-jcSP/68nD4bxAZBT8o5R5NpMzjKjZ2CgYDqa7mfX/Y0=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_7 = {
+    version = rubyVersion "3" "3" "7" "";
+    hash = "sha256-nDfDsSKIx67CDKEhznaEW+W7XXdmKiSRllGq8dEshig=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_8 = {
+    version = rubyVersion "3" "3" "8" "";
+    hash = "sha256-WuKKh6WaPkrWa8KTHSMturlT0KqPa687xPj4CXfInKs=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_9 = {
+    version = rubyVersion "3" "3" "9" "";
+    hash = "sha256-0ZkWkKThcjPsazx4RMHhJFwK3OPgDXE1UdBFhGe3J7E=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_10 = {
     version = rubyVersion "3" "3" "10" "";
     hash = "sha256-tVW6pGejBs/I5sbtJNDSeyfpob7R2R2VUJhZ6saw6Sg=";
-    cargoHash = "sha256-xE7Cv+NVmOHOlXa/Mg72CTSaZRb72lOja98JBvxPvSs=";
+    cargoHash = cargoHash_3_3;
   };
 
-  v3_4 = {
+  v3_3_11 = {
+    version = rubyVersion "3" "3" "11" "";
+    hash = "sha256-WfD6+xpZoF3DdlEXrz+mjhU+tIJUcIVJ8yHB6eB416A=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  v3_3_12 = {
+    version = rubyVersion "3" "3" "12" "";
+    hash = "sha256-sG1jvq4nGTMDPifwo4m8WCoAnnhFNX1ENlw53lJaBRs=";
+    cargoHash = cargoHash_3_3;
+  };
+
+  # Ruby 3.4.x
+  v3_4_0 = {
+    version = rubyVersion "3" "4" "0" "";
+    hash = "sha256-BoyFI0QhdL00AOeG9KaVI1LIKxufYhD9F/tIIwhtM3k=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_1 = {
+    version = rubyVersion "3" "4" "1" "";
+    hash = "sha256-PTheXSLTaLBkyBehPtjjzD9xp3BdftG654ATwzqnyH8=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_2 = {
+    version = rubyVersion "3" "4" "2" "";
+    hash = "sha256-QTKKwh8r/dfeazVl708N11QzVNN+lvFXoVUqa9DrNks=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_3 = {
+    version = rubyVersion "3" "4" "3" "";
+    hash = "sha256-VaTNHcvlyifPZeiak1pILCuyKEgyk5JmVRwOxotDf0Y=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_4 = {
+    version = rubyVersion "3" "4" "4" "";
+    hash = "sha256-oFl7/fMS4BDv0e/6qNfx14MxRv3BeVDKqBWP+j3L+oU=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_5 = {
+    version = rubyVersion "3" "4" "5" "";
+    hash = "sha256-HYjYontEL93kqgbcmehrC78LKIlj2EMxEt1frHmP1e4=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_6 = {
+    version = rubyVersion "3" "4" "6" "";
+    hash = "sha256-48Gauej0GzcjEk+8ARTN58v1XmWqnFjBKs2J7JwN0bk=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_7 = {
+    version = rubyVersion "3" "4" "7" "";
+    hash = "sha256-I4FabQlWlveRkJD9w+L5RZssg9VyJLLkRs4fX3Mz7zY=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_8 = {
+    version = rubyVersion "3" "4" "8" "";
+    hash = "sha256-U8TdrUH7thifH17g21elHVS9H4f4dVs9aGBBVqNbBFs=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  v3_4_9 = {
     version = rubyVersion "3" "4" "9" "";
     hash = "sha256-e7TU9egHzCclHRTZ1ghtGCxbJYdRkeRKsVtwnNen3Zw=";
-    cargoHash = "sha256-5Tp8Kth0yO89/LIcU8K01z6DdZRr8MAA0DPKqDEjIt0=";
+    cargoHash = cargoHash_3_4;
   };
 
-  v4_0 = {
-    version = rubyVersion "4" "0" "0" "preview3";
-    hash = "sha256-Q9CSbndvvVWZrcx7zLTMyAThCfQCogaGB6KoZWLCzcA=";
-    cargoHash = "sha256-z7NwWc4TaR042hNx0xgRkh/BQEpEJtE53cfrN0qNiE0=";
+  v3_4_10 = {
+    version = rubyVersion "3" "4" "10" "";
+    hash = "sha256-7O4tByoU8tFDR91W39j+XDEwq/URe/qsvaD075zEKew=";
+    cargoHash = cargoHash_3_4;
+  };
+
+  # Ruby 4.0.x
+  v4_0_0 = {
+    version = rubyVersion "4" "0" "0" "";
+    hash = "sha256-LoOJyMByy2WMk6E3JzLZ6shAgsiLBldQ2x5SpaxjAnE=";
+    cargoHash = cargoHash_4_0;
+  };
+
+  v4_0_1 = {
+    version = rubyVersion "4" "0" "1" "";
+    hash = "sha256-OSS+LQXbMPTjX4Wb8Ci+hfS33QFxQUL9gj5K9d4vr50=";
+    cargoHash = cargoHash_4_0;
+  };
+
+  v4_0_2 = {
+    version = rubyVersion "4" "0" "2" "";
+    hash = "sha256-UVArJrULaN9JYzNspB42jN6SySj6+RZU3kxMF5H4Kqw=";
+    cargoHash = cargoHash_4_0;
+  };
+
+  v4_0_3 = {
+    version = rubyVersion "4" "0" "3" "";
+    hash = "sha256-d5ZKzDcNXIN1uVAuW6bBPAPvkaueufUhyE+0K5yaaw8=";
+    cargoHash = cargoHash_4_0;
+  };
+
+  v4_0_4 = {
+    version = rubyVersion "4" "0" "4" "";
+    hash = "sha256-819u36Pauz9yP50M8ZBsZRKud/TkEqseaMxukdIw+oA=";
+    cargoHash = cargoHash_4_0;
+  };
+
+  v4_0_5 = {
+    version = rubyVersion "4" "0" "5" "";
+    hash = "sha256-fWFJB5pj+K4dMmyfplxgGbotwxVerns5FZgXkRyIlY4=";
+    cargoHash = cargoHash_4_0;
+  };
+
+  v4_0_6 = {
+    version = rubyVersion "4" "0" "6" "";
+    hash = "sha256-g30pno993yvjGiKaen4BnTVJeYJRF5iayzsysam+Jio=";
+    cargoHash = cargoHash_4_0;
   };
 }

--- a/pkgs/pnpmFixupStateDb/default.nix
+++ b/pkgs/pnpmFixupStateDb/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  nodejs' ? nodejs.v23,
+  nodejs' ? nodejs,
   nodejs,
   pnpm,
   tests,

--- a/top-level.nix
+++ b/top-level.nix
@@ -244,7 +244,7 @@ with final;
   mscgen = null;
   multipath-tools = null;
   neovim = null;
-  nodejs_latest = nodejs.v23;
+  nodejs_latest = nodejs.v26;
   nwdiag = null;
   nixos-icons = null; # imagemagick tests
   objgraph = null;


### PR DESCRIPTION
Fill out go, rust, node, ruby ecosystems with most of their interpreters. This makes them available by default.

Add fzf, ripgrep, tmux, because I like them