### PR TITLE
ekaos: tune kernel performance

### DIFF
--- a/ekaos/modules/config/kernel-profile.nix
+++ b/ekaos/modules/config/kernel-profile.nix
@@ -1,0 +1,154 @@
+# Kernel tuning profiles
+#
+# Selects runtime sysctl values, kernel boot parameters, and power management
+# defaults appropriate for a given workload.  Compile-time kernel config
+# (PREEMPT, HZ, BFQ, BBR, etc.) is set in common-config.nix and already
+# targets interactive desktop use.  These profiles tune the *runtime* knobs
+# on top of that base.
+{
+  config,
+  lib,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.boot.kernel.profile;
+
+  # ── profile definitions ──────────────────────────────────────────────
+  #
+  # Each profile is an attrset of:
+  #   sysctl   – merged into boot.kernel.sysctl
+  #   params   – appended to boot.kernelParams
+  #   power    – sets power.cpuFreqGovernor (null = don't touch)
+  profiles = {
+
+    reactive = {
+      description = "Optimised for responsive desktop / laptop use (default)";
+      sysctl = {
+        # Swap less aggressively — keep working set in RAM
+        "vm.swappiness" = 10;
+        # Flush dirty pages earlier to avoid bursty I/O stalls
+        "vm.dirty_ratio" = 10;
+        "vm.dirty_background_ratio" = 5;
+        # Prefer keeping dentries/inodes over page cache
+        "vm.vfs_cache_pressure" = 50;
+        # Moderate proactive compaction to reduce allocation stalls
+        "vm.compaction_proactiveness" = 20;
+        # Limit watermark boost to reduce kswapd wake-ups
+        "vm.watermark_boost_factor" = 1;
+        # Lower watermark scale — reclaim starts closer to low watermark
+        "vm.watermark_scale_factor" = 125;
+        # Increase minimum free kbytes for smoother allocations (64 MiB)
+        "vm.min_free_kbytes" = 65536;
+      };
+      params = [ ];
+      power = null;
+    };
+
+    balanced = {
+      description = "General purpose — moderate latency and power use";
+      sysctl = {
+        "vm.swappiness" = 30;
+        "vm.dirty_ratio" = 15;
+        "vm.dirty_background_ratio" = 5;
+        "vm.vfs_cache_pressure" = 100;
+        "vm.compaction_proactiveness" = 20;
+      };
+      params = [ ];
+      power = null;
+    };
+
+    battery = {
+      description = "Maximise battery life on laptops";
+      sysctl = {
+        # Allow more swap to free RAM earlier
+        "vm.swappiness" = 60;
+        # Let dirty pages accumulate longer — fewer disk wake-ups
+        "vm.dirty_ratio" = 30;
+        "vm.dirty_background_ratio" = 10;
+        "vm.vfs_cache_pressure" = 100;
+        # Disable proactive compaction to save CPU
+        "vm.compaction_proactiveness" = 0;
+      };
+      params = [
+        # Re-enable power-efficient workqueues even if the compiled default
+        # were to change in the future
+        "workqueue.power_efficient=1"
+        # Deeper NMI watchdog sleep
+        "nmi_watchdog=0"
+      ];
+      power = "powersave";
+    };
+
+    low-power = {
+      description = "Embedded / always-on devices — minimise CPU wake-ups";
+      sysctl = {
+        "vm.swappiness" = 80;
+        "vm.dirty_ratio" = 40;
+        "vm.dirty_background_ratio" = 15;
+        "vm.vfs_cache_pressure" = 150;
+        "vm.compaction_proactiveness" = 0;
+      };
+      params = [
+        "workqueue.power_efficient=1"
+        "nmi_watchdog=0"
+        "processor.max_cstate=5"
+      ];
+      power = "powersave";
+    };
+
+    performance = {
+      description = "Workstation / compute — lowest latency, ignore power use";
+      sysctl = {
+        # Almost never swap
+        "vm.swappiness" = 1;
+        # Flush dirty pages eagerly to avoid stalls
+        "vm.dirty_ratio" = 5;
+        "vm.dirty_background_ratio" = 3;
+        # Reclaim dentries/inodes aggressively in favour of data
+        "vm.vfs_cache_pressure" = 50;
+        # Maximum proactive compaction
+        "vm.compaction_proactiveness" = 50;
+        "vm.watermark_boost_factor" = 1;
+        "vm.watermark_scale_factor" = 125;
+        "vm.min_free_kbytes" = 131072;
+        # Disable NUMA balancing overhead if not needed
+        "kernel.numa_balancing" = 0;
+      };
+      params = [
+        # Disable power-efficient workqueues for lowest latency
+        "workqueue.power_efficient=0"
+      ];
+      power = "performance";
+    };
+
+  };
+
+  chosen = profiles.${cfg};
+in
+
+{
+  options.boot.kernel.profile = mkOption {
+    type = types.enum (attrNames profiles);
+    default = "reactive";
+    example = "battery";
+    description = ''
+      Kernel tuning profile.  Selects runtime sysctl values, boot
+      parameters, and a CPU frequency governor appropriate for the
+      workload.
+
+      Available profiles:
+      ${concatStringsSep "\n" (mapAttrsToList (n: p: "- ${n}: ${p.description}") profiles)}
+    '';
+  };
+
+  config = {
+    boot.kernel.sysctl = mapAttrs (_: mkDefault) chosen.sysctl;
+
+    boot.kernelParams = chosen.params;
+
+    power.cpuFreqGovernor = mkIf (chosen.power != null) (mkDefault chosen.power);
+  };
+}

--- a/ekaos/modules/module-list.nix
+++ b/ekaos/modules/module-list.nix
@@ -43,6 +43,7 @@
   ./config/locale.nix
   ./config/fonts.nix
   ./config/power.nix
+  ./config/kernel-profile.nix
   ./config/xdg/mime.nix
   ./config/xdg/icons.nix
   ./config/xdg/autostart.nix

--- a/pkgs/linux-support/kernel/common-config.nix
+++ b/pkgs/linux-support/kernel/common-config.nix
@@ -257,7 +257,9 @@ let
       MQ_IOSCHED_DEADLINE = yes;
       BFQ_GROUP_IOSCHED = yes;
       MQ_IOSCHED_KYBER = yes;
-      IOSCHED_BFQ = module;
+      # Build BFQ into the kernel so it is available immediately (no module load
+      # delay).  Zen and XanMod already do this for desktop responsiveness.
+      IOSCHED_BFQ = yes;
       # Enable CPU utilization clamping for RT tasks
       UCLAMP_TASK = yes;
       UCLAMP_TASK_GROUP = yes;
@@ -267,6 +269,11 @@ let
       # Enable Full Dynticks System.
       # NO_HZ_FULL depends on HAVE_VIRT_CPU_ACCOUNTING_GEN depends on 64BIT
       NO_HZ_FULL = lib.mkIf stdenv.hostPlatform.is64bit yes;
+      # 1000 Hz tick rate for low scheduling latency and smooth interactive
+      # response.  This matches Zen and Fedora desktop defaults.
+      # Use mkDefault so kernel variants (e.g. XanMod) can override.
+      HZ = lib.mkDefault (freeform "1000");
+      HZ_1000 = lib.mkDefault yes;
     };
 
     # Enable NUMA.
@@ -297,6 +304,14 @@ let
       WAN = yes;
       TCP_CONG_ADVANCED = yes;
       TCP_CONG_CUBIC = yes; # This is the default congestion control algorithm since 2.6.19
+      # BBR provides better throughput and lower latency on lossy networks
+      # (Wi-Fi, cellular, congested links) compared to CUBIC.
+      TCP_CONG_BBR = yes;
+      DEFAULT_BBR = yes;
+      # Use FQ-Codel as the default queueing discipline for lower latency
+      # and reduced bufferbloat.
+      NET_SCH_DEFAULT = yes;
+      DEFAULT_FQ_CODEL = yes;
       # Required by systemd per-cgroup firewalling
       CGROUP_BPF = option yes;
       CGROUP_NET_PRIO = yes; # Required by systemd
@@ -1346,8 +1361,10 @@ let
         HMM_MIRROR = yes;
         DRM_AMDGPU_USERPTR = yes;
 
-        PREEMPT = no;
-        PREEMPT_VOLUNTARY = yes;
+        # Full kernel preemption for responsive desktop/interactive use.
+        # This matches Zen, XanMod, Fedora, and Ubuntu desktop defaults.
+        PREEMPT = yes;
+        PREEMPT_VOLUNTARY = no;
 
         X86_AMD_PLATFORM_DEVICE = lib.mkIf stdenv.hostPlatform.isx86 yes;
         X86_PLATFORM_DRIVERS_DELL = lib.mkIf stdenv.hostPlatform.isx86 (whenAtLeast "5.12" yes);

--- a/pkgs/linux-support/kernel/generic.nix
+++ b/pkgs/linux-support/kernel/generic.nix
@@ -120,16 +120,10 @@ let
         features = kernelFeatures; # Ensure we know of all extra patches, etc.
       };
 
-      # TODO(corepkgs): This references NixOS modules, repleace with EkaOS usage
-      #intermediateNixConfig =
-      #  configfile.moduleStructuredConfig.intermediateNixConfig
-      #  # extra config in legacy string format
-      #  + extraConfig;
-
-      # (corepkgs): placeholder for now
       intermediateNixConfig =
+        configfile.moduleStructuredConfig.intermediateNixConfig
         # extra config in legacy string format
-        extraConfig;
+        + extraConfig;
 
       structuredConfigFromPatches = map (
         {

--- a/pkgs/linux-support/kernel/kernels-org.json
+++ b/pkgs/linux-support/kernel/kernels-org.json
@@ -21,7 +21,7 @@
     },
     "6.12": {
         "version": "6.12.107",
-        "hash": "sha256:1fpsyac0322lnlyh99hrjsdcf6zfxh275fk9pspfvl9r04z8gzjj",
+        "hash": "sha256:0yih5s4xbp1hlyfha49z2j3l9x7i5ij335jfl6f6sbfy7yzcby55",
         "lts": true
     },
     "6.6": {


### PR DESCRIPTION
Add `boot.kernel.profile` which allows for people to generally optimize for a particular kernel speed profile.

Optimize existing kernel profile for desktop responsiveness.