### PR TITLE
mkShell, mkShellNoCC: init

### DIFF
--- a/build-support/mkshell/default.nix
+++ b/build-support/mkshell/default.nix
@@ -1,0 +1,67 @@
+# A derivation that is only meant to be consumed by nix-shell / nix develop.
+# mkShellNoCC is this with stdenvNoCC.
+{
+  lib,
+  stdenv,
+}:
+# A special kind of derivation that is only meant to be consumed by the
+# nix-shell.
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  excludeDrvArgNames = [
+    "packages"
+    "inputsFrom"
+  ];
+
+  extendDrvArgs =
+    _finalAttrs:
+    {
+      name ? "nix-shell",
+      # a list of packages to add to the shell environment
+      packages ? [ ],
+      # propagate all the inputs from the given derivations
+      inputsFrom ? [ ],
+      ...
+    }@attrs:
+    let
+      mergeInputs =
+        name:
+        (attrs.${name} or [ ])
+        ++
+          # 1. get all `{build,nativeBuild,...}Inputs` from the elements of `inputsFrom`
+          # 2. since that is a list of lists, `flatten` that into a regular list
+          # 3. filter out of the result everything that's in `inputsFrom` itself
+          # this leaves actual dependencies of the derivations in `inputsFrom`, but never the derivations themselves
+          (lib.subtractLists inputsFrom (lib.flatten (lib.catAttrs name inputsFrom)));
+    in
+    {
+      inherit name;
+
+      buildInputs = mergeInputs "buildInputs";
+      nativeBuildInputs = packages ++ (mergeInputs "nativeBuildInputs");
+      propagatedBuildInputs = mergeInputs "propagatedBuildInputs";
+      propagatedNativeBuildInputs = mergeInputs "propagatedNativeBuildInputs";
+
+      shellHook = lib.concatStringsSep "\n" (
+        lib.catAttrs "shellHook" (lib.reverseList inputsFrom ++ [ attrs ])
+      );
+
+      phases = attrs.phases or [ "buildPhase" ];
+
+      buildPhase =
+        attrs.buildPhase or ''
+          { echo "------------------------------------------------------------";
+            echo " WARNING: the existence of this path is not guaranteed.";
+            echo " It is an internal implementation detail for pkgs.mkShell.";
+            echo "------------------------------------------------------------";
+            echo;
+            # Record all build inputs as runtime dependencies
+            export;
+          } >> "$out"
+        '';
+
+      preferLocalBuild = attrs.preferLocalBuild or true;
+      allowSubstitutes = attrs.allowSubstitutes or false;
+    };
+}

--- a/top-level.nix
+++ b/top-level.nix
@@ -80,6 +80,10 @@ with final;
   # Creates development environments with running services using ekaos modules
   mkDevShell = (callPackage ./dev-shell { }).mkDevShell;
 
+  # Traditional nix-shell / nix develop wrapper (packages, inputsFrom, shellHook).
+  mkShell = callPackage ./build-support/mkshell { };
+  mkShellNoCC = mkShell.override { stdenv = stdenvNoCC; };
+
   # vmTools - VM building utilities for ekaosTest and disk image creation
   vmTools = callPackage ./build-support/vm { };
   makeInitrd = callPackage ./build-support/kernel/make-initrd.nix;


### PR DESCRIPTION
Adds `pkgs.mkShell` and `pkgs.mkShellNoCC` — the usual nix-shell / nix develop wrapper (`packages`, `inputsFrom`, `shellHook`).

`build-support/docker/examples.nix` already evaluates `pkgs.mkShell`; the attr was missing from the package set. `mkShellNoCC` is `mkShell.override { stdenv = stdenvNoCC; }`.

This is the traditional helper, not `mkDevShell` (ekaos services).