### PR TITLE
ghc: add the 9.10.3 bindist, and let terminfo link

### DIFF
--- a/haskell/configuration-ghc-9.10.x.nix
+++ b/haskell/configuration-ghc-9.10.x.nix
@@ -1,0 +1,52 @@
+# Configuration for GHC 9.10.x
+# Primarily nulls out core libraries that ship with GHC.
+{ pkgs, haskellLib }:
+
+self: super:
+
+{
+  # Disable GHC 9.10.x core libraries.
+  array = null;
+  base = null;
+  binary = null;
+  bytestring = null;
+  Cabal = null;
+  Cabal-syntax = null;
+  containers = null;
+  deepseq = null;
+  directory = null;
+  exceptions = null;
+  filepath = null;
+  ghc-bignum = null;
+  ghc-boot = null;
+  ghc-boot-th = null;
+  ghc-compact = null;
+  ghc-experimental = null;
+  ghc-heap = null;
+  ghc-internal = null;
+  ghc-platform = null;
+  ghc-prim = null;
+  ghc-toolchain = null;
+  ghci = null;
+  haskeline = null;
+  hpc = null;
+  integer-gmp = null;
+  mtl = null;
+  os-string = null;
+  parsec = null;
+  pretty = null;
+  process = null;
+  rts = null;
+  semaphore-compat = null;
+  stm = null;
+  system-cxx-std-lib = null;
+  template-haskell = null;
+  terminfo =
+    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then null else super.terminfo or null;
+  text = null;
+  time = null;
+  transformers = null;
+  unix = null;
+  xhtml = null;
+  Win32 = null;
+}

--- a/haskell/default.nix
+++ b/haskell/default.nix
@@ -78,15 +78,23 @@ in
   compiler = {
     ghc902Binary = pkgs.ghc.v9_0_2_binary;
     ghc984Binary = pkgs.ghc.v9_8_4_binary;
+    ghc9103Binary = pkgs.ghc.v9_10_3_binary;
   };
 
   # Per-compiler package sets
   packages =
     let
       ghc98Config = import ./configuration-ghc-9.8.x.nix { inherit pkgs haskellLib; };
+      ghc910Config = import ./configuration-ghc-9.10.x.nix { inherit pkgs haskellLib; };
       ghc90Config = import ./configuration-ghc-9.0.x.nix { };
     in
     {
+      ghc9103Binary = mkPackageSet {
+        ghc = pkgs.ghc.v9_10_3_binary;
+        ghcAttr = "ghc9103Binary";
+        compilerConfig = ghc910Config;
+      };
+
       ghc984Binary = mkPackageSet {
         ghc = pkgs.ghc.v9_8_4_binary;
         ghcAttr = "ghc984Binary";

--- a/pkgs-many/ghc/9.10.3-binary.nix
+++ b/pkgs-many/ghc/9.10.3-binary.nix
@@ -25,8 +25,8 @@ assert stdenv.targetPlatform == stdenv.hostPlatform;
 let
   downloadsUrl = "https://downloads.haskell.org/ghc";
 
-  # Copy sha256 from https://downloads.haskell.org/~ghc/9.8.4/SHA256SUMS
-  version = "9.8.4";
+  # Copy sha256 from https://downloads.haskell.org/~ghc/9.10.3/SHA256SUMS
+  version = "9.10.3";
 
   # Information about available bindists that we use in the build.
   #
@@ -52,7 +52,7 @@ let
         variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-i386-deb10-linux.tar.xz";
-          sha256 = "e5efce16c654d5e702986258a87dd9531e1722b8051823c8ce1150ce3c5899ae";
+          sha256 = "dc4d941d2240b5a3cd0d2de7b91b2184f60afb27ab8c4a66a9fce82f8cae4c89";
         };
         exePathForLibraryCheck = "bin/ghc";
         archSpecificLibraries = [
@@ -70,7 +70,7 @@ let
         variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-deb11-linux.tar.xz";
-          sha256 = "af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad";
+          sha256 = "b6bbd3514e0cdb9db350812a003bb7c670c58d99779086fbe41092b019548924";
         };
         exePathForLibraryCheck = "bin/ghc";
         archSpecificLibraries = [
@@ -88,7 +88,7 @@ let
         variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-deb11-linux.tar.xz";
-          sha256 = "310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3";
+          sha256 = "052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008";
         };
         exePathForLibraryCheck = "bin/ghc";
         archSpecificLibraries = [
@@ -106,7 +106,7 @@ let
         variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
-          sha256 = "de7baacfb1513ab0e4ccf8911045cceee84bc8a4e39b89bd975ed3135e5f7d96";
+          sha256 = "01e4ff9530c124408db0b0f9ec7e4be35b300a6aee939c5758d1acf22d51693f";
         };
         exePathForLibraryCheck = null; # we don't have a library check for darwin yet
         archSpecificLibraries = [
@@ -128,7 +128,7 @@ let
         variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-apple-darwin.tar.xz";
-          sha256 = "e2f12a922754fd28511512875bf6d9eb3e0cce7fc963a7266f6e1661aeabd7ed";
+          sha256 = "9f50ddd87be5cb994c719402778d6c7fdd341934fd4fbc0fcc3ecb40d49f860c";
         };
         exePathForLibraryCheck = null; # we don't have a library check for darwin yet
         archSpecificLibraries = [
@@ -153,7 +153,7 @@ let
         variantSuffix = "-musl";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-alpine3_18-linux.tar.xz";
-          sha256 = "b5c86a0cda0bd62d5eeeb52b1937c3bd00c70cd67dd74226ce787d5c429a4e62";
+          sha256 = "4866d3b241c59860f2f6eaa2a5e96632113e57100b911ff8aa936665cc0045fe";
         };
         exePathForLibraryCheck = "bin/ghc";
         archSpecificLibraries = [
@@ -171,7 +171,7 @@ let
         variantSuffix = "-musl";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3_12-linux.tar.xz";
-          sha256 = "e34bb16e8387509adc96a3d98b4a444bab425d12864c38a3629f2860b4bec2e7";
+          sha256 = "c8863098401febaab6892536b363deda109a75fea437abb992d58103d402ed89";
         };
         exePathForLibraryCheck = "bin/ghc";
         archSpecificLibraries = [
@@ -359,7 +359,7 @@ stdenv.mkDerivation (finalAttrs: {
     done
   ''
   # Use ld.gold instead of ld.bfd to avoid relocation errors with binutils >= 2.44.
-  # GHC 9.8.x produces object files with relocations that confuse ld.bfd.
+  # GHC 9.8.x and 9.10.x produce object files with relocations that confuse ld.bfd.
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     settings="$out/lib/ghc-${version}/lib/settings"
     sed -i \

--- a/pkgs-many/ghc/variants.nix
+++ b/pkgs-many/ghc/variants.nix
@@ -9,4 +9,8 @@
     version = "9.8.4-binary";
     isBinary = true;
   };
+  v9_10_3_binary = {
+    version = "9.10.3-binary";
+    isBinary = true;
+  };
 }


### PR DESCRIPTION
## GHC 9.10.3 bindist and a `haskell.packages.ghc9103Binary` set

corepkgs ships GHC as bindists — 9.0.2 and 9.8.4 today. This adds 9.10.3 the same way, next to them; the default `haskellPackages` is untouched.

**What lands**

- `pkgs-many/ghc/9.10.3-binary.nix`: `9.8.4-binary.nix` with the version and the seven bindist hashes from `https://downloads.haskell.org/~ghc/9.10.3/SHA256SUMS`; same distribution variants (deb10 i386, deb11 x86_64/aarch64, alpine 3.12/3.18 musl, both darwins), same `archSpecificLibraries` checks (gmp, `libtinfo.so.6`), same ld.gold settings patch.
- `pkgs-many/ghc/variants.nix`: `v9_10_3_binary`.
- `haskell/configuration-ghc-9.10.x.nix`: the core libraries GHC 9.10 ships, nulled — the 9.8 list plus `ghc-experimental`, `ghc-internal`, `ghc-platform`, `ghc-toolchain`, `os-string`, `semaphore-compat`.
- `haskell/default.nix`: `compiler.ghc9103Binary` and `packages.ghc9103Binary`.
- Both `9.8.4-binary.nix` and `9.10.3-binary.nix`: the bindists' `terminfo` package links `-ltinfo` and expects it on the system, so anything using haskeline failed to link (`ld: cannot find -ltinfo`). Its package-db entry now points at ncurses, the way `ghc-bignum`'s is pointed at gmp.

**Why**

The haskell-pkgs snapshot is Stackage LTS 24, which targets GHC 9.10: packages there assume `base-4.20`, `Cabal-3.12` and `os-string` as a core library. Pairing it with 9.8.4 works for much of Hackage but not for a project whose `cabal-version` is 3.12 (GHC 9.8.4's Cabal is 3.10.3.0 and rejects it). With this set, such a project — [telomare](https://github.com/Stand-In-Language/stand-in-language) is the one that prompted it — builds on ekapkgs unchanged.

**Checked**

- `nix build .#legacyPackages.x86_64-linux.haskell.compiler.ghc9103Binary` — the bindist unpacks, patches and passes the library checks on x86_64-linux.
- With haskell-pkgs' `pkgs-module.nix` folded in: telomare (library, three executables, five test suites) and its tool set (`haskell-language-server`, `hlint`, `stylish-haskell`, `ghcid`, `cabal-install`) build against `ghc9103Binary`. <!-- fill in what was actually built -->

**Not decided here**

Whether `haskellPackages` should move to 9.10.3 to match the snapshot. This keeps 9.8.4 as the default so nothing downstream changes.

**Noticed along the way** (not addressed here): `git`'s documentation build fails with `asciidoc: command not found` (`gitMinimal` builds); `writeShellApplication`'s default `checkPhase` and `haskellSrc2nix` reference `shellcheck-minimal` and `cabal2nix-unwrapped`, which no repository in the ecosystem defines; `haskellPackages.cabal-install` needs Cabal 3.16 in its scope on either compiler; `hw-fingertree` needs a jailbreak on 9.10.
