### PR TITLE
ghc.v9_10_3_binary: fix the musl hash and two follow-ups to #178

### DIFF
--- a/pkgs-many/ghc/9.10.3-binary.nix
+++ b/pkgs-many/ghc/9.10.3-binary.nix
@@ -171,7 +171,7 @@ let
         variantSuffix = "-musl";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3_12-linux.tar.xz";
-          sha256 = "c8863098401febaab6892536b363deda109a75fea437abb992d58103d402ed89";
+          sha256 = "0ad0335849dd69672fd8ac1c168237aa5a88e8890b25fe703942957961816067";
         };
         exePathForLibraryCheck = "bin/ghc";
         archSpecificLibraries = [

--- a/pkgs-many/ghc/9.10.3-binary.nix
+++ b/pkgs-many/ghc/9.10.3-binary.nix
@@ -201,6 +201,13 @@ let
       ) binDistUsed.archSpecificLibraries
     )).nixPackage;
 
+  ncursesUsed =
+    (builtins.head (
+      builtins.filter (
+        drv: lib.hasPrefix "ncurses" (drv.nixPackage.name or "")
+      ) binDistUsed.archSpecificLibraries
+    )).nixPackage;
+
   libPath = lib.makeLibraryPath (
     # Add arch-specific libraries.
     map ({ nixPackage, ... }: nixPackage) binDistUsed.archSpecificLibraries
@@ -293,7 +300,7 @@ stdenv.mkDerivation (finalAttrs: {
     # nothing that uses haskeline links.
     + ''
       find . -name 'terminfo*.conf' \
-          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib ncurses.v6}/lib' -i {} \;
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib ncursesUsed}/lib' -i {} \;
     ''
     # Similar for iconv and libffi on darwin
     + lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs-many/ghc/9.10.3-binary.nix
+++ b/pkgs-many/ghc/9.10.3-binary.nix
@@ -437,7 +437,7 @@ stdenv.mkDerivation (finalAttrs: {
         # shell wrapper scripts that GHC uses for its bin/ commands.
         # The interpreter was already set in postUnpack.
         ''
-          ghcLibDir="$out/lib/ghc-${version}/lib/x86_64-linux-ghc-${version}"
+          ghcLibDir=$(echo "$out"/lib/ghc-${version}/lib/*-ghc-${version})
           for i in "$out/bin/"*; do
             test ! -h "$i" || continue
             isScript "$i" || continue
@@ -461,7 +461,7 @@ stdenv.mkDerivation (finalAttrs: {
     # where we modify the package db before installing.
     # Use LD_LIBRARY_PATH since we don't patchelf RPATHs.
     + ''
-      ghcLibDir="$out/lib/ghc-${version}/lib/x86_64-linux-ghc-${version}"
+      ghcLibDir=$(echo "$out"/lib/ghc-${version}/lib/*-ghc-${version})
       package_db=("$out"/lib/ghc-*/lib/package.conf.d)
       LD_LIBRARY_PATH="${libPath}:$ghcLibDir''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
         "$out/bin/ghc-pkg" --package-db="$package_db" recache

--- a/pkgs-many/ghc/9.8.4-binary.nix
+++ b/pkgs-many/ghc/9.8.4-binary.nix
@@ -201,6 +201,13 @@ let
       ) binDistUsed.archSpecificLibraries
     )).nixPackage;
 
+  ncursesUsed =
+    (builtins.head (
+      builtins.filter (
+        drv: lib.hasPrefix "ncurses" (drv.nixPackage.name or "")
+      ) binDistUsed.archSpecificLibraries
+    )).nixPackage;
+
   libPath = lib.makeLibraryPath (
     # Add arch-specific libraries.
     map ({ nixPackage, ... }: nixPackage) binDistUsed.archSpecificLibraries
@@ -293,7 +300,7 @@ stdenv.mkDerivation (finalAttrs: {
     # nothing that uses haskeline links.
     + ''
       find . -name 'terminfo*.conf' \
-          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib ncurses.v6}/lib' -i {} \;
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib ncursesUsed}/lib' -i {} \;
     ''
     # Similar for iconv and libffi on darwin
     + lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
Hi! I'm a bit ashamed to disclose that my ghc-9.10 PR was a bit of an overstep from my fable session.

I left it running last night before going to bed because I still had fable tokens and my weekly reset was at 2 am and I didn't want to waste them so I fired a flable 5.1 max session to port a project to ekala from vanilla nix and gave it instructions to fork and work on keeping ghc-9.10, and resulted in also doing a PR with not enough review. Sorry about that, I've fixed my permission settings.

I've been evaluating the PR and reviewing it and there are a couple of mistakes and a false claim that it works with HLS. Currently working on a haskell-pkgs PR to have that claim be true.
This is fable's description of what was wrong in my runaway PR:

> **What was wrong in #178**
>
> 1. **Wrong hash for the x86_64 musl bindist.** The `alpine3_12` entry carried the sha256 of `ghc-9.10.3-x86_64-fedora33-linux.tar.xz`, the neighbouring line in upstream's `SHA256SUMS`. Nothing in corepkgs builds the musl variant, which is why neither the build nor CI noticed. The other six hashes are right.
> 2. **The "Checked" list overclaimed.** It said haskell-language-server builds against `ghc9103Binary` (next to a leftover `<!-- fill in what was actually built -->`). It does not: HLS 2.13's formatters (ormolu 0.8, fourmolu 0.19) need Cabal-syntax 3.14 where GHC 9.10 bundles 3.12, so the closure ends up with two Cabal-syntax instances. `cabal-install` built only with Cabal 3.16 put in its scope. What did build on the set: a project with `cabal-version: 3.12` and its test suites, plus hlint, stylish-haskell and ghcid. The HLS fix belongs in haskell-pkgs (its overlay is composed after the compiler configuration, so a compiler-config override is discarded); it is being prepared there.
> 3. **An undisclosed side effect.** The terminfo `library-dirs` fix was also applied to `9.8.4-binary.nix`, which changes the default compiler's derivation and so invalidated its cache entry. The fix itself is right (the bindists' `terminfo` package links `-ltinfo` and finds it nowhere), but it should have been a separate commit and said so.
> 4. **Inherited assumptions.** `9.10.3-binary.nix` is `9.8.4-binary.nix` with the version and hashes changed, so it also inherited the `x86_64-linux-ghc-<version>` library directory hard-coded in the wrapper and recache steps for every Linux system. Only x86_64-linux was built; the other six platform entries are unverified copies.

**This PR**

- `ghc.v9_10_3_binary: fix the x86_64 musl bindist hash` — the alpine3_12 sha256 now matches `SHA256SUMS` and `nix store prefetch-file` of that tarball.
- `ghc-binary: take the ncurses package from archSpecificLibraries` — the terminfo fix now derives `ncursesUsed` the way `gmpUsed` is derived, in both bindists. The rendered path is identical, so **neither derivation changes** (checked by comparing `drvPath` before and after); no cache invalidation this time.
- `ghc.v9_10_3_binary: stop hard-coding the x86_64 library directory` — the two `ghcLibDir=` lines glob the arch directory instead. 9.10.3 only, to leave 9.8.4's derivation alone.

Verified on x86_64-linux: the rebuilt 9.10.3 bindist has the same file set and byte-identical wrappers (modulo store path) as before, `passthru.tests.{hello,templateHaskell}` pass, `ci/eval.sh` evaluates all 2071 packages, nixfmt is clean. The musl fix is verified by prefetch only, since there is no musl package set to build it with.

Not in this PR: HLS (haskell-pkgs, coming), and the per-version copy of the bindist file — with three copies whose diff is nine lines, a shared `mkBinaryGhc { version, hashes }` in `generic.nix` would be the next cleanup if you want it.

