### PR TITLE
darwin: unixtools name, libarchive iconv, nodejs gyp, rustc-bootstrap LLVM

### DIFF
--- a/pkgs-many/nodejs/generic.nix
+++ b/pkgs-many/nodejs/generic.nix
@@ -37,6 +37,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = src-hash;
   };
 
+  # Sandboxed Darwin (and CLT-less builders) have no Xcode/CLT receipts.
+  # Hardcode Catalina's CLT version so gyp's XcodeVersion() does not call
+  # xcodebuild/pkgutil. Same fallback nixpkgs uses.
+  patches = lib.optionals stdenv.buildPlatform.isDarwin [
+    ./gyp-patches-set-fallback-value-for-CLT-darwin.patch
+  ];
+
   nativeBuildInputs = [
     python
     which

--- a/pkgs-many/nodejs/generic.nix
+++ b/pkgs-many/nodejs/generic.nix
@@ -20,6 +20,8 @@
   brotli,
   pkg-config,
   callPackage,
+  unixtools,
+  cctools ? null,
 }:
 
 let
@@ -48,6 +50,14 @@ stdenv.mkDerivation (finalAttrs: {
     python
     which
     pkg-config
+  ]
+  ++ lib.optionals stdenv.buildPlatform.isDarwin [
+    # gyp checks `sysctl -n hw.memsize` if `sys.platform == "darwin"`.
+    unixtools.sysctl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # gyp-mac-tool ExecFilterLibtool runs `libtool` (Apple's, from cctools).
+    cctools.libtool
   ];
 
   buildInputs = [

--- a/pkgs-many/nodejs/gyp-patches-set-fallback-value-for-CLT-darwin.patch
+++ b/pkgs-many/nodejs/gyp-patches-set-fallback-value-for-CLT-darwin.patch
@@ -1,0 +1,64 @@
+Sandboxed builds need a fallback value for the version of the Command Line Tools
+being used. Not calling `CLTVersion()` avoids relying on absolute paths,
+improving the reproducibility of non-sandboxed builds.
+
+diff --git a/tools/gyp/pylib/gyp/xcode_emulation.py b/tools/gyp/pylib/gyp/xcode_emulation.py
+index 508f6ccac3e..44bcd988c4c 100644
+--- a/tools/gyp/pylib/gyp/xcode_emulation.py
++++ b/tools/gyp/pylib/gyp/xcode_emulation.py
+@@ -1495,24 +1495,8 @@ def XcodeVersion():
+     global XCODE_VERSION_CACHE
+     if XCODE_VERSION_CACHE:
+         return XCODE_VERSION_CACHE
+-    version = ""
++    version = "11.0.0.0.1.1567737322"
+     build = ""
+-    try:
+-        version_list = GetStdoutQuiet(["xcodebuild", "-version"]).splitlines()
+-        # In some circumstances xcodebuild exits 0 but doesn't return
+-        # the right results; for example, a user on 10.7 or 10.8 with
+-        # a bogus path set via xcode-select
+-        # In that case this may be a CLT-only install so fall back to
+-        # checking that version.
+-        if len(version_list) < 2:
+-            raise GypError("xcodebuild returned unexpected results")
+-        version = version_list[0].split()[-1]  # Last word on first line
+-        build = version_list[-1].split()[-1]  # Last word on last line
+-    except (GypError, OSError):
+-        # Xcode not installed so look for XCode Command Line Tools
+-        version = CLTVersion()  # macOS Catalina returns 11.0.0.0.1.1567737322
+-        if not version:
+-            raise GypError("No Xcode or CLT version detected!")
+     # Be careful to convert "4.2.3" to "0423" and "11.0.0" to "1100":
+     version = version.split(".")[:3]  # Just major, minor, micro
+     version[0] = version[0].zfill(2)  # Add a leading zero if major is one digit
+ 
+ 
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
+@@ -1495,24 +1495,8 @@ def XcodeVersion():
+     global XCODE_VERSION_CACHE
+     if XCODE_VERSION_CACHE:
+         return XCODE_VERSION_CACHE
+-    version = ""
++    version = "11.0.0.0.1.1567737322"
+     build = ""
+-    try:
+-        version_list = GetStdoutQuiet(["xcodebuild", "-version"]).splitlines()
+-        # In some circumstances xcodebuild exits 0 but doesn't return
+-        # the right results; for example, a user on 10.7 or 10.8 with
+-        # a bogus path set via xcode-select
+-        # In that case this may be a CLT-only install so fall back to
+-        # checking that version.
+-        if len(version_list) < 2:
+-            raise GypError("xcodebuild returned unexpected results")
+-        version = version_list[0].split()[-1]  # Last word on first line
+-        build = version_list[-1].split()[-1]  # Last word on last line
+-    except (GypError, OSError):
+-        # Xcode not installed so look for XCode Command Line Tools
+-        version = CLTVersion()  # macOS Catalina returns 11.0.0.0.1.1567737322
+-        if not version:
+-            raise GypError("No Xcode or CLT version detected!")
+     # Be careful to convert "4.2.3" to "0423" and "11.0.0" to "1100":
+     version = version.split(".")[:3]  # Just major, minor, micro
+     version[0] = version[0].zfill(2)  # Add a leading zero if major is one digit

--- a/pkgs-many/rust/binary.nix
+++ b/pkgs-many/rust/binary.nix
@@ -64,6 +64,19 @@ rec {
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       install_name_tool -change "/usr/lib/libcurl.4.dylib" \
       "${lib.getLib curl}/lib/libcurl.4.dylib" "$out/bin/cargo"
+      # Official dist rustc ships @rpath/libLLVM.dylib (LLVM 22 here).
+      # Clang 21 also ships libLLVM.dylib. If both directories are on the
+      # dyld search path, clang-21 binds LLVM symbols to the bootstrap copy
+      # and abort-traps (missing _LLVMInitializeLanaiAsmParser). Give the
+      # bootstrap LLVM a unique id so it cannot collide.
+      if [ -e "$out/lib/libLLVM.dylib" ]; then
+        mv "$out/lib/libLLVM.dylib" "$out/lib/libLLVM-rustc.dylib"
+        install_name_tool -id '@rpath/libLLVM-rustc.dylib' "$out/lib/libLLVM-rustc.dylib"
+        for f in "$out/bin/"* "$out/lib/"*.dylib; do
+          [ -f "$f" ] || continue
+          install_name_tool -change '@rpath/libLLVM.dylib' '@rpath/libLLVM-rustc.dylib' "$f" || true
+        done
+      fi
     '';
 
     # The strip tool in cctools 973.0.1 and up appears to break rlibs in the

--- a/pkgs/libarchive/default.nix
+++ b/pkgs/libarchive/default.nix
@@ -10,6 +10,7 @@
   lzo,
   openssl,
   pkg-config,
+  libiconv,
   xz,
   zlib,
   zstd,
@@ -93,6 +94,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     acl
     attr
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # GNU libiconv: Darwin's libc iconv does not export __libiconv_version,
+    # which libarchive records when it sees GNU iconv headers (via libxml2).
+    libiconv.real
   ]
   ++ lib.optional xarSupport libxml2;
 

--- a/unixtools.nix
+++ b/unixtools.nix
@@ -267,6 +267,7 @@ let
   makeCompat =
     pname: paths:
     buildEnv {
+      name = "${pname}-${version}";
       inherit paths pname version;
     };
 


### PR DESCRIPTION
Follow-ups to #184, found while evaluating and building [juspay/olai#527](https://github.com/juspay/olai/pull/527) on aarch64-darwin (CLT-less builder, no Xcode receipts).

- **unixtools.makeCompat**: `buildEnv` now requires `name`. Darwin `pkgs.procps` is that compat env; Linux uses `procps-ng` and does not hit this path.
- **libarchive**: link `libiconv.real` on Darwin. Darwin libc iconv does not export `__libiconv_version`; GNU headers arrive via libxml2.
- **nodejs**: Darwin-only GYP CLT fallback (nixpkgs' Catalina version) so `XcodeVersion()` does not call xcodebuild/pkgutil.
- **nodejs**: Darwin `nativeBuildInputs` for gyp — `unixtools.sysctl` (`hw.memsize`) and `cctools.libtool` (`gyp-mac-tool` `ExecFilterLibtool`).
- **rustc-bootstrap**: give the dist `libLLVM.dylib` (LLVM 22) a unique id so clang-21 does not bind `_LLVMInitializeLanaiAsmParser` to it.

`nix build` of olai succeeded on aarch64-darwin after these. lint and eval CI are green.